### PR TITLE
Allow running in a separate namespace for "staging" environment

### DIFF
--- a/deploy/k8s/garden_app.yaml
+++ b/deploy/k8s/garden_app.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: garden-app
-  namespace: default
 spec:
   replicas: 1
   selector:
@@ -16,6 +15,7 @@ spec:
       containers:
         - name: garden-app
           image: ghcr.io/calvinmclean/garden-app
+          imagePullPolicy: Always
           ports:
             - containerPort: 80
           volumeMounts:
@@ -34,7 +34,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: garden-app
-  namespace: default
 spec:
   type: NodePort
   selector:
@@ -48,7 +47,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: garden-app-config
-  namespace: default
 data:
   config.yaml: |
     web_server:
@@ -65,7 +63,7 @@ data:
       address: "http://influxdb:8086"
       token: "my-secret-token"
       org: "garden"
-      bucket: "water"
+      bucket: "garden"
     storage:
       type: "ConfigMap"
       options:
@@ -73,8 +71,8 @@ data:
         key: "gardens.yaml"
   gardens.yaml: |
     c9i98glvqc7km2vasfig:
-        name: Seed Starting
-        topic_prefix: seeds
+        name: Garden
+        topic_prefix: garden
         id: c9i98glvqc7km2vasfig
         zones:
             c9i99otvqc7kmt8hjio0:

--- a/deploy/k8s/grafana.yaml
+++ b/deploy/k8s/grafana.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana
-  namespace: default
 spec:
   replicas: 1
   selector:
@@ -67,7 +66,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: grafana
-  namespace: default
 spec:
   type: NodePort
   selector:
@@ -81,7 +79,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-config
-  namespace: default
 data:
   datasource.yml: |
     apiVersion: 1

--- a/deploy/k8s/influxdb.yaml
+++ b/deploy/k8s/influxdb.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: influxdb
-  namespace: default
 spec:
   replicas: 1
   selector:
@@ -31,7 +30,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: influxdb
-  namespace: default
 spec:
   type: NodePort
   selector:

--- a/deploy/k8s/mosquitto.yaml
+++ b/deploy/k8s/mosquitto.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mosquitto
-  namespace: default
 spec:
   replicas: 1
   selector:
@@ -30,7 +29,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: mosquitto
-  namespace: default
 spec:
   type: NodePort
   selector:
@@ -44,7 +42,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: mosquitto-config
-  namespace: default
 data:
   mosquitto.conf: |
     listener 1883

--- a/deploy/k8s/persistent_volume.yaml
+++ b/deploy/k8s/persistent_volume.yaml
@@ -7,7 +7,7 @@ spec:
     storage: 2Gi
   volumeMode: Filesystem
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   persistentVolumeReclaimPolicy: Delete
   storageClassName: local-storage
   local:
@@ -15,11 +15,11 @@ spec:
   nodeAffinity:
     required:
       nodeSelectorTerms:
-      - matchExpressions:
-        - key: kubernetes.io/hostname
-          operator: In
-          values:
-          - nuc
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - nuc
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -32,3 +32,4 @@ spec:
   resources:
     requests:
       storage: 2Gi
+# Note: in order for this to work, I had to make the directory first and then chown /opt/garden-data/grafana to 472:root

--- a/deploy/k8s/shared_env.yaml
+++ b/deploy/k8s/shared_env.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: shared-environment
-  namespace: default
 data:
   # General
   ADMIN_USER: admin

--- a/deploy/k8s/telegraf.yaml
+++ b/deploy/k8s/telegraf.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: telegraf
-  namespace: default
 spec:
   replicas: 1
   selector:
@@ -25,11 +24,26 @@ spec:
                 configMapKeyRef:
                   name: shared-environment
                   key: MQTT_WATER_TOPIC
+            - name: MQTT_LIGHT_TOPIC
+              valueFrom:
+                configMapKeyRef:
+                  name: shared-environment
+                  key: MQTT_LIGHT_TOPIC
             - name: MQTT_MOISTURE_TOPIC
               valueFrom:
                 configMapKeyRef:
                   name: shared-environment
                   key: MQTT_MOISTURE_TOPIC
+            - name: MQTT_LOGGING_TOPIC
+              valueFrom:
+                configMapKeyRef:
+                  name: shared-environment
+                  key: MQTT_LOGGING_TOPIC
+            - name: MQTT_HEALTH_TOPIC
+              valueFrom:
+                configMapKeyRef:
+                  name: shared-environment
+                  key: MQTT_HEALTH_TOPIC
             - name: INFLUXDB_TOKEN
               valueFrom:
                 configMapKeyRef:
@@ -54,7 +68,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: telegraf-config
-  namespace: default
 data:
   telegraf.conf: |
     [global_tags]

--- a/deploy/skaffold/grafana.yaml
+++ b/deploy/skaffold/grafana.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana
-  namespace: default
 spec:
   replicas: 1
   selector:
@@ -61,7 +60,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: grafana
-  namespace: default
 spec:
   type: NodePort
   selector:
@@ -75,7 +73,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-config
-  namespace: default
 data:
   datasource.yml: |
     apiVersion: 1

--- a/deploy/skaffold/influxdb.yaml
+++ b/deploy/skaffold/influxdb.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: influxdb
-  namespace: default
 spec:
   replicas: 1
   selector:

--- a/deploy/skaffold/mock_controller.yaml
+++ b/deploy/skaffold/mock_controller.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: garden-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: garden-controller
+  template:
+    metadata:
+      labels:
+        app: garden-controller
+    spec:
+      containers:
+        - name: garden-controller
+          image: ghcr.io/calvinmclean/garden-app
+          volumeMounts:
+            - name: config
+              mountPath: /config
+          args:
+            - controller
+            - --config
+            - /config/config.yaml
+            - --enable-ui=false
+      volumes:
+        - name: config
+          configMap:
+            name: garden-controller-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: garden-controller-config
+data:
+  config.yaml: |
+    mqtt:
+      broker: "mosquitto"
+      port: 1883
+      client_id: "garden-controller"
+      water_topic: "{{.Garden}}/command/water"
+      stop_topic: "{{.Garden}}/command/stop"
+      stop_all_topic: "{{.Garden}}/command/stop_all"
+      light_topic: "{{.Garden}}/command/light"
+    controller:
+      topic_prefix: "garden"
+      num_zones: 3
+      moisture_strategy: increasing
+      moisture_value: 0
+      moisture_interval: 30s
+      publish_water_event: true
+      publish_health: true
+      health_interval: 1m

--- a/garden-app/api/openapi.yaml
+++ b/garden-app/api/openapi.yaml
@@ -425,7 +425,7 @@ paths:
               $ref: "#/components/schemas/ZoneAction"
 
   /gardens/{gardenID}/zones/{zoneID}/history:
-    post:
+    get:
       tags:
         - zones
       summary: Get Zone's watering history

--- a/garden-app/controller/controller.go
+++ b/garden-app/controller/controller.go
@@ -39,7 +39,7 @@ type NestedConfig struct {
 	MoistureStrategy  string        `mapstructure:"moisture_strategy"`
 	MoistureValue     int           `mapstructure:"moisture_value"`
 	MoistureInterval  time.Duration `mapstructure:"moisture_interval"`
-	PublishWaterEvent bool          `mapstructure:"publish_watering_event"`
+	PublishWaterEvent bool          `mapstructure:"publish_water_event"`
 	PublishHealth     bool          `mapstructure:"publish_health"`
 	HealthInterval    time.Duration `mapstructure:"health_interval"`
 	EnableUI          bool          `mapstructure:"enable_ui"`

--- a/garden-app/pkg/influxdb/client.go
+++ b/garden-app/pkg/influxdb/client.go
@@ -16,7 +16,7 @@ const (
 |> range(start: -{{.Start}})
 |> filter(fn: (r) => r["_measurement"] == "moisture")
 |> filter(fn: (r) => r["_field"] == "value")
-|> filter(fn: (r) => r["plant"] == "{{.PlantPosition}}")
+|> filter(fn: (r) => r["zone"] == "{{.ZonePosition}}")
 |> filter(fn: (r) => r["topic"] == "{{.TopicPrefix}}/data/moisture")
 |> mean()`
 	healthQueryTemplate = `from(bucket: "{{.Bucket}}")
@@ -29,7 +29,7 @@ const (
 |> range(start: -{{.Start}})
 |> filter(fn: (r) => r["_measurement"] == "water")
 |> filter(fn: (r) => r["topic"] == "{{.TopicPrefix}}/data/water")
-|> filter(fn: (r) => r["plant"] == "{{.PlantPosition}}")
+|> filter(fn: (r) => r["zone"] == "{{.ZonePosition}}")
 |> sort(columns: ["_time"], desc: true)
 {{- if .Limit }}
 |> limit(n: {{.Limit}})
@@ -39,11 +39,11 @@ const (
 
 // queryData is used to fill out any of the query templates
 type queryData struct {
-	Bucket        string
-	Start         time.Duration
-	PlantPosition uint
-	TopicPrefix   string
-	Limit         uint64
+	Bucket       string
+	Start        time.Duration
+	ZonePosition uint
+	TopicPrefix  string
+	Limit        uint64
 }
 
 // Render executes the specified template with the queryData to create a string
@@ -88,13 +88,13 @@ func NewClient(config Config) Client {
 }
 
 // GetMoisture returns the plant's average soil moisture in the last 15 minutes
-func (client *client) GetMoisture(ctx context.Context, plantPosition uint, topicPrefix string) (result float64, err error) {
+func (client *client) GetMoisture(ctx context.Context, zonePosition uint, topicPrefix string) (result float64, err error) {
 	// Prepare query
 	queryString, err := queryData{
-		Bucket:        client.config.Bucket,
-		Start:         time.Minute * 15,
-		PlantPosition: plantPosition,
-		TopicPrefix:   topicPrefix,
+		Bucket:       client.config.Bucket,
+		Start:        time.Minute * 15,
+		ZonePosition: zonePosition,
+		TopicPrefix:  topicPrefix,
 	}.Render(moistureQueryTemplate)
 	if err != nil {
 		return
@@ -143,14 +143,14 @@ func (client *client) GetLastContact(ctx context.Context, topicPrefix string) (r
 }
 
 // GetWaterHistory gets recent water events for a specific Plant
-func (client *client) GetWaterHistory(ctx context.Context, plantPosition uint, topicPrefix string, timeRange time.Duration, limit uint64) ([]map[string]interface{}, error) {
+func (client *client) GetWaterHistory(ctx context.Context, zonePosition uint, topicPrefix string, timeRange time.Duration, limit uint64) ([]map[string]interface{}, error) {
 	// Prepare query
 	queryString, err := queryData{
-		Bucket:        client.config.Bucket,
-		Start:         timeRange,
-		TopicPrefix:   topicPrefix,
-		PlantPosition: plantPosition,
-		Limit:         limit,
+		Bucket:       client.config.Bucket,
+		Start:        timeRange,
+		TopicPrefix:  topicPrefix,
+		ZonePosition: zonePosition,
+		Limit:        limit,
 	}.Render(waterHistoryQueryTemplate)
 	if err != nil {
 		return nil, err

--- a/garden-app/pkg/storage/configmap.go
+++ b/garden-app/pkg/storage/configmap.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 
 	"github.com/calvinmclean/automated-garden/garden-app/pkg"
 	"github.com/rs/xid"
@@ -49,7 +50,12 @@ func NewConfigMapClient(config Config) (*ConfigMapClient, error) {
 		return nil, fmt.Errorf("unable to create Clientset: %v", err)
 	}
 
-	client.k8sClient = clientset.CoreV1().ConfigMaps("default")
+	namespace, err := ioutil.ReadFile("/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return nil, fmt.Errorf("unable to read namespace from file: %v", err)
+	}
+
+	client.k8sClient = clientset.CoreV1().ConfigMaps(string(namespace))
 
 	// Get the ConfigMap and read into map
 	err = client.update()


### PR DESCRIPTION
This goal of this PR is to be able to run everything, including a containerized instance of `garden-app controller` in a separate namespace so it can be used a staging environment to test out certain things without a physical hardware controller.

I also ended up fixing a few minor bugs that I ran into when testing this out.

In order to deploy to a separate namespace, a few manual changes must be made to the files, like PVC settings and NodePorts. I don't want to create a new directory `/deploy/staging` because it'll be more files to keep consistent when there are just minor changes. I also don't want to go through the effort of setting up a Helm Chart yet...