### PR TITLE
Add minimum interval for getting RainData

### DIFF
--- a/garden-app/pkg/weather/netatmo/rain.go
+++ b/garden-app/pkg/weather/netatmo/rain.go
@@ -4,8 +4,15 @@ import (
 	"time"
 )
 
+const minRainInterval = 24 * time.Hour
+
 // GetTotalRain returns the sum of all rainfall in millimeters in the given period
 func (c *Client) GetTotalRain(since time.Duration) (float32, error) {
+	// Time to check from must always be at least 24 hours to get valid data
+	if since < minRainInterval {
+		since = minRainInterval
+	}
+
 	beginDate := time.Now().Add(-since)
 	rainData, err := c.getMeasure("sum_rain", "1day", beginDate, nil)
 	if err != nil {


### PR DESCRIPTION
- Prevents error caused by empty data. If an interval is less than 24 hours, it is reasonable to still check for rain in 24 hour period

Closes #26