### PR TITLE
Implement common restrictEndDatedMiddleware

### DIFF
--- a/garden-app/server/end_dated.go
+++ b/garden-app/server/end_dated.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/render"
+)
+
+// endDateable is a simple interface that requires a method to determine if something is end-dated
+type endDateable interface {
+	EndDated() bool
+}
+
+// restrictEndDatedMiddleware will get an EedDateable resource from context and return an error if it is end-dated
+func restrictEndDatedMiddleware(resourceName string, ctxKey contextKey) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resource := r.Context().Value(ctxKey).(endDateable)
+			logger := getLoggerFromContext(r.Context())
+
+			if resource.EndDated() {
+				err := fmt.Errorf("resource not available for end-dated %s", resourceName)
+				logger.WithError(err).Error("unable to complete request")
+				render.Render(w, r, ErrInvalidRequest(err))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/garden-app/server/garden.go
+++ b/garden-app/server/garden.go
@@ -78,22 +78,6 @@ func NewGardenResource(config Config, logger *logrus.Entry, storageClient storag
 	return gr, nil
 }
 
-// restrictEndDatedMiddleware will return a 400 response if the requested Garden is end-dated
-func (gr GardensResource) restrictEndDatedMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		garden := getGardenFromContext(r.Context())
-		logger := getLoggerFromContext(r.Context())
-
-		if garden.EndDated() {
-			err := fmt.Errorf("resource not available for end-dated Garden")
-			logger.WithError(err).Error("unable to complete request")
-			render.Render(w, r, ErrInvalidRequest(err))
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
 // gardenContextMiddleware middleware is used to load a Garden object from the URL
 // parameters passed through as the request. In case the Garden could not be found,
 // we stop here and return a 404.

--- a/garden-app/server/garden_test.go
+++ b/garden-app/server/garden_test.go
@@ -138,7 +138,6 @@ func TestGardenContextMiddleware(t *testing.T) {
 }
 
 func TestGardenRestrictEndDatedMiddleware(t *testing.T) {
-	gr := GardensResource{}
 	garden := createExampleGarden()
 	endDatedGarden := createExampleGarden()
 	endDate := time.Now().Add(-1 * time.Minute)
@@ -149,7 +148,7 @@ func TestGardenRestrictEndDatedMiddleware(t *testing.T) {
 
 	router := chi.NewRouter()
 	router.Route("/garden", func(r chi.Router) {
-		r.Use(gr.restrictEndDatedMiddleware)
+		r.Use(restrictEndDatedMiddleware("Garden", gardenCtxKey))
 		r.Get("/", testHandler)
 	})
 

--- a/garden-app/server/server.go
+++ b/garden-app/server/server.go
@@ -101,7 +101,7 @@ func NewServer(cfg Config) (*Server, error) {
 
 			// Add new middleware to restrict certain paths to non-end-dated Gardens
 			r.Route("/", func(r chi.Router) {
-				r.Use(gardenResource.restrictEndDatedMiddleware)
+				r.Use(restrictEndDatedMiddleware("Garden", gardenCtxKey))
 				r.Post("/action", gardenResource.gardenAction)
 
 				r.Route(plantBasePath, func(r chi.Router) {
@@ -130,7 +130,7 @@ func NewServer(cfg Config) (*Server, error) {
 
 						// Add new middleware to restrict certain paths to non-end-dated Zones
 						r.Route("/", func(r chi.Router) {
-							r.Use(zonesResource.restrictEndDatedMiddleware)
+							r.Use(restrictEndDatedMiddleware("Zone", zoneCtxKey))
 
 							r.Post("/action", zonesResource.zoneAction)
 							r.Get("/history", zonesResource.waterHistory)

--- a/garden-app/server/zone.go
+++ b/garden-app/server/zone.go
@@ -52,22 +52,6 @@ func NewZonesResource(gr GardensResource, logger *logrus.Entry) (ZonesResource, 
 	return zr, err
 }
 
-// restrictEndDatedMiddleware will return a 400 response if the requested Zone is end-dated
-func (zr ZonesResource) restrictEndDatedMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		zone := getZoneFromContext(r.Context())
-		logger := getLoggerFromContext(r.Context())
-
-		if zone.EndDated() {
-			err := fmt.Errorf("resource not available for end-dated Zone")
-			logger.WithError(err).Error("unable to complete request")
-			render.Render(w, r, ErrInvalidRequest(err))
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
 // zoneContextMiddleware middleware is used to load a Zone object from the URL
 // parameters passed through as the request. In case the Zone could not be found,
 // we stop here and return a 404.

--- a/garden-app/server/zone_test.go
+++ b/garden-app/server/zone_test.go
@@ -115,9 +115,6 @@ func TestZoneContextMiddleware(t *testing.T) {
 }
 
 func TestZoneRestrictEndDatedMiddleware(t *testing.T) {
-	pr := ZonesResource{
-		GardensResource: GardensResource{},
-	}
 	zone := createExampleZone()
 	endDatedZone := createExampleZone()
 	endDate := time.Now().Add(-1 * time.Minute)
@@ -128,7 +125,7 @@ func TestZoneRestrictEndDatedMiddleware(t *testing.T) {
 
 	router := chi.NewRouter()
 	router.Route("/zone", func(r chi.Router) {
-		r.Use(pr.restrictEndDatedMiddleware)
+		r.Use(restrictEndDatedMiddleware("Zone", zoneCtxKey))
 		r.Get("/", testHandler)
 	})
 


### PR DESCRIPTION
- Use a simple EndDateable interface to implement a common middleware to restrict access to end-dated API resources

Closes #93