### PR TITLE
Increase test coverage: change some tests to use KV storage instead of using mock

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Test
         working-directory: ./${{ env.PROJECT_NAME }}
-        run: go test -short -v -race -covermode=atomic -coverprofile=coverage.out ./...
+        run: go test -short -race -covermode=atomic -coverprofile=coverage.out ./...
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
@@ -86,7 +86,7 @@ jobs:
 
       - name: Integration Test
         working-directory: ./${{ env.PROJECT_NAME }}
-        run: sleep 15 && go test -v -race -covermode=atomic -coverprofile=integration_coverage.out -coverpkg=./... ./integration_tests
+        run: sleep 15 && go test -race -covermode=atomic -coverprofile=integration_coverage.out -coverpkg=./... ./integration_tests
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,3 +15,4 @@ ignore:
   - docs
   - garden-app/pkg/weather/netatmo # ignore because it is basically untestable
   - "*_test.go"
+  - "mock*.go"

--- a/garden-app/integration_tests/testdata/config.yml
+++ b/garden-app/integration_tests/testdata/config.yml
@@ -14,8 +14,9 @@ influxdb:
   org: "garden"
   bucket: "garden"
 storage:
-  type: "YAML"
+  type: "kv"
   options:
+    driver: hashmap
     filename: "testdata/gardens.yml"
 
 controller:

--- a/garden-app/integration_tests/testdata/gardens_test.yml
+++ b/garden-app/integration_tests/testdata/gardens_test.yml
@@ -1,35 +1,33 @@
-gardens:
-  c9i98glvqc7km2vasfig:
-    name: Test
-    topic_prefix: test
-    id: c9i98glvqc7km2vasfig
-    plants:
-      c9i9jl5vqc7l7e3ikkgg:
-        name: Plant
-        details:
-          description: My favorite plant
-          notes: Planted from seed
-          time_to_harvest: 70 days
-          count: 1
-        id: c9i9jl5vqc7l7e3ikkgg
-        zone_id: c9i99otvqc7kmt8hjio0
-        created_at: 2022-04-23T17:29:08.526638-07:00
-    zones:
-      c9i99otvqc7kmt8hjio0:
-        name: Zone 1
-        id: c9i99otvqc7kmt8hjio0
-        position: 0
-        created_at: 2022-04-23T17:08:03.441727-07:00
-        water_schedule_ids: [chkodpg3lcj13q82mq40]
-    max_zones: 3
-    created_at: 2022-04-23T17:05:22.245112-07:00
-    light_schedule:
-      duration: 14h
-      start_time: 22:00:00-07:00
-water_schedules:
-  chkodpg3lcj13q82mq40:
-    id: chkodpg3lcj13q82mq40
-    duration: 10s
-    interval: 24h
-    start_time: 2022-04-23T08:00:00-07:00
-    weathercontrol: null
+Garden_c9i98glvqc7km2vasfig: |
+  name: Test
+  topic_prefix: test
+  id: c9i98glvqc7km2vasfig
+  plants:
+    c9i9jl5vqc7l7e3ikkgg:
+      name: Plant
+      details:
+        description: My favorite plant
+        notes: Planted from seed
+        time_to_harvest: 70 days
+        count: 1
+      id: c9i9jl5vqc7l7e3ikkgg
+      zone_id: c9i99otvqc7kmt8hjio0
+      created_at: 2022-04-23T17:29:08.526638-07:00
+  zones:
+    c9i99otvqc7kmt8hjio0:
+      name: Zone 1
+      id: c9i99otvqc7kmt8hjio0
+      position: 0
+      created_at: 2022-04-23T17:08:03.441727-07:00
+      water_schedule_ids: [chkodpg3lcj13q82mq40]
+  max_zones: 3
+  created_at: 2022-04-23T17:05:22.245112-07:00
+  light_schedule:
+    duration: 14h
+    start_time: 22:00:00-07:00
+WaterSchedule_chkodpg3lcj13q82mq40: |
+  id: chkodpg3lcj13q82mq40
+  duration: 10s
+  interval: 24h
+  start_time: 2022-04-23T08:00:00-07:00
+  weathercontrol: null

--- a/garden-app/worker/scheduler_test.go
+++ b/garden-app/worker/scheduler_test.go
@@ -163,6 +163,10 @@ func TestGetNextWaterTime(t *testing.T) {
 }
 
 func TestScheduleLightActions(t *testing.T) {
+	// TODO: this test was consistently failing when running in GitHub Workflow, but worked fine locally until this commit which
+	// changed line 199 of `scheduler.go` (ScheduleLightActions) to delete and re-create Job instead of updating. It's interesting
+	// because it used to work fine, so I need to double-check that this these tests are actually testing what I think they are.
+	// In other words, this test sometimes tests the update job and sometimes doesn't, depending on when it is run
 	t.Run("AdhocOnTimeInFutureOverridesScheduled", func(t *testing.T) {
 		worker := NewWorker(nil, nil, nil, logrus.New())
 		worker.StartAsync()
@@ -178,9 +182,7 @@ func TestScheduleLightActions(t *testing.T) {
 		}
 
 		nextOnTime := worker.GetNextLightTime(g, pkg.LightStateOn)
-		if *nextOnTime != later {
-			t.Errorf("Unexpected nextOnTime: expected=%v, actual=%v", later, *nextOnTime)
-		}
+		assert.Equal(t, later, *nextOnTime)
 	})
 	t.Run("AdhocOnTimeInPastIsNotUsed", func(t *testing.T) {
 		storageClient := new(storage.MockClient)


### PR DESCRIPTION
In an effort to increase code coverage, I want to move some tests to use the in-memory KV client instead of relying on mocks.

I might not end up doing this in all tests because it will be a major refactor and make it impossible to test some error scenarios, but I will see what can be done. I am also making some changes to the codecov configuration to exclude more files.