### PR TITLE
Get WaterSchedule from storage in scheduled job

### DIFF
--- a/garden-app/controller/assertions.go
+++ b/garden-app/controller/assertions.go
@@ -23,7 +23,7 @@ func (c *Controller) AssertWaterActions(t *testing.T, expected ...action.WaterMe
 
 	c.assertionData.Lock()
 	assert.Equal(t, expected, c.assertionData.waterActions)
-	c.assertionData.waterActions = []action.WaterMessage{}
+	c.assertionData.waterActions = nil
 	c.assertionData.Unlock()
 }
 

--- a/garden-app/pkg/storage/generic.go
+++ b/garden-app/pkg/storage/generic.go
@@ -12,6 +12,10 @@ import (
 // getOne will use the provided key to read data from the data source. Then, it will Unmarshal
 // into the generic type
 func getOne[T any](c *Client, key string) (*T, error) {
+	if c.db == nil {
+		return nil, fmt.Errorf("error missing database connection")
+	}
+
 	dataBytes, err := c.db.Get(key)
 	if err != nil {
 		if errors.Is(hord.ErrNil, err) {

--- a/garden-app/server/weather_clients_test.go
+++ b/garden-app/server/weather_clients_test.go
@@ -316,7 +316,7 @@ func TestCreateWeatherClient(t *testing.T) {
 	}{
 		{
 			"Successful",
-			`{"id":"c5cvhpcbcv45e8bp16dg","type":"fake","options":{"avg_high_temperature":80,"rain_interval":"24h","rain_mm":25.4},"links":[{"rel":"self","href":"/weather_clients/c5cvhpcbcv45e8bp16dg"}]}`,
+			`{"type":"fake","options":{"avg_high_temperature":80,"rain_interval":"24h","rain_mm":25.4}}`,
 			`{"id":"[0-9a-v]{20}","type":"fake","options":{"avg_high_temperature":80,"rain_interval":"24h","rain_mm":25.4},"links":\[{"rel":"self","href":"/weather_clients/[0-9a-v]{20}"}\]}`,
 			http.StatusCreated,
 		},


### PR DESCRIPTION
- Instead of having to implement more specific checks and reset scheduled jobs in the PATCH endpoint, reading from storage at runtime will reduce chances of other issues as well

Closes #138