### PR TITLE
Generic GET API handler

### DIFF
--- a/garden-app/server/context.go
+++ b/garden-app/server/context.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 
-	"github.com/calvinmclean/automated-garden/garden-app/pkg"
 	"github.com/sirupsen/logrus"
 )
 
@@ -62,10 +61,10 @@ func getWeatherClientFromContext(ctx context.Context) *WeatherClientResponse {
 	return ctx.Value(weatherClientCtxKey).(*WeatherClientResponse)
 }
 
-func newContextWithWaterSchedule(ctx context.Context, ws *pkg.WaterSchedule) context.Context {
+func newContextWithWaterSchedule(ctx context.Context, ws *WaterScheduleResponse) context.Context {
 	return context.WithValue(ctx, waterScheduleCtxKey, ws)
 }
 
-func getWaterScheduleFromContext(ctx context.Context) *pkg.WaterSchedule {
-	return ctx.Value(waterScheduleCtxKey).(*pkg.WaterSchedule)
+func getWaterScheduleFromContext(ctx context.Context) *WaterScheduleResponse {
+	return ctx.Value(waterScheduleCtxKey).(*WaterScheduleResponse)
 }

--- a/garden-app/server/context.go
+++ b/garden-app/server/context.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/calvinmclean/automated-garden/garden-app/pkg"
-	"github.com/calvinmclean/automated-garden/garden-app/pkg/weather"
 	"github.com/sirupsen/logrus"
 )
 
@@ -55,12 +54,12 @@ func getPlantFromContext(ctx context.Context) *PlantResponse {
 	return ctx.Value(plantCtxKey).(*PlantResponse)
 }
 
-func newContextWithWeatherClient(ctx context.Context, wc *weather.Config) context.Context {
+func newContextWithWeatherClient(ctx context.Context, wc *WeatherClientResponse) context.Context {
 	return context.WithValue(ctx, weatherClientCtxKey, wc)
 }
 
-func getWeatherClientFromContext(ctx context.Context) *weather.Config {
-	return ctx.Value(weatherClientCtxKey).(*weather.Config)
+func getWeatherClientFromContext(ctx context.Context) *WeatherClientResponse {
+	return ctx.Value(weatherClientCtxKey).(*WeatherClientResponse)
 }
 
 func newContextWithWaterSchedule(ctx context.Context, ws *pkg.WaterSchedule) context.Context {

--- a/garden-app/server/context.go
+++ b/garden-app/server/context.go
@@ -39,12 +39,12 @@ func getGardenFromContext(ctx context.Context) *GardenResponse {
 	return ctx.Value(gardenCtxKey).(*GardenResponse)
 }
 
-func newContextWithZone(ctx context.Context, z *pkg.Zone) context.Context {
+func newContextWithZone(ctx context.Context, z *ZoneResponse) context.Context {
 	return context.WithValue(ctx, zoneCtxKey, z)
 }
 
-func getZoneFromContext(ctx context.Context) *pkg.Zone {
-	return ctx.Value(zoneCtxKey).(*pkg.Zone)
+func getZoneFromContext(ctx context.Context) *ZoneResponse {
+	return ctx.Value(zoneCtxKey).(*ZoneResponse)
 }
 
 func newContextWithPlant(ctx context.Context, p *PlantResponse) context.Context {

--- a/garden-app/server/context.go
+++ b/garden-app/server/context.go
@@ -31,12 +31,12 @@ func getLoggerFromContext(ctx context.Context) *logrus.Entry {
 	return logger
 }
 
-func newContextWithGarden(ctx context.Context, g *pkg.Garden) context.Context {
+func newContextWithGarden(ctx context.Context, g *GardenResponse) context.Context {
 	return context.WithValue(ctx, gardenCtxKey, g)
 }
 
-func getGardenFromContext(ctx context.Context) *pkg.Garden {
-	return ctx.Value(gardenCtxKey).(*pkg.Garden)
+func getGardenFromContext(ctx context.Context) *GardenResponse {
+	return ctx.Value(gardenCtxKey).(*GardenResponse)
 }
 
 func newContextWithZone(ctx context.Context, z *pkg.Zone) context.Context {
@@ -47,12 +47,12 @@ func getZoneFromContext(ctx context.Context) *pkg.Zone {
 	return ctx.Value(zoneCtxKey).(*pkg.Zone)
 }
 
-func newContextWithPlant(ctx context.Context, p *pkg.Plant) context.Context {
+func newContextWithPlant(ctx context.Context, p *PlantResponse) context.Context {
 	return context.WithValue(ctx, plantCtxKey, p)
 }
 
-func getPlantFromContext(ctx context.Context) *pkg.Plant {
-	return ctx.Value(plantCtxKey).(*pkg.Plant)
+func getPlantFromContext(ctx context.Context) *PlantResponse {
+	return ctx.Value(plantCtxKey).(*PlantResponse)
 }
 
 func newContextWithWeatherClient(ctx context.Context, wc *weather.Config) context.Context {

--- a/garden-app/server/generic.go
+++ b/garden-app/server/generic.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-chi/render"
+)
+
+func get[T render.Renderer](getter func(context.Context) T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		logger := getLoggerFromContext(r.Context())
+
+		resource := getter(r.Context())
+		logger.Debugf("responding with resource: %+v", resource)
+
+		if err := render.Render(w, r, resource); err != nil {
+			logger.WithError(err).Error("unable to render response")
+			render.Render(w, r, ErrRender(err))
+		}
+	}
+}

--- a/garden-app/server/plant_test.go
+++ b/garden-app/server/plant_test.go
@@ -83,7 +83,7 @@ func TestGetPlant(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pr := PlantsResource{
-				GardensResource: GardensResource{
+				GardensResource: &GardensResource{
 					storageClient: setupZonePlantGardenStorage(t),
 				},
 			}
@@ -137,7 +137,7 @@ func TestUpdatePlant(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pr := PlantsResource{
-				GardensResource: GardensResource{
+				GardensResource: &GardensResource{
 					storageClient: setupZonePlantGardenStorage(t),
 				},
 			}
@@ -185,7 +185,7 @@ func TestEndDatePlant(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pr := PlantsResource{
-				GardensResource: GardensResource{
+				GardensResource: &GardensResource{
 					storageClient: storageClient,
 				},
 			}
@@ -244,7 +244,7 @@ func TestGetAllPlants(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pr := PlantsResource{
-				GardensResource: GardensResource{
+				GardensResource: &GardensResource{
 					storageClient: storageClient,
 				},
 			}
@@ -310,7 +310,7 @@ func TestCreatePlant(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pr := PlantsResource{
-				GardensResource: GardensResource{
+				GardensResource: &GardensResource{
 					storageClient: setupZonePlantGardenStorage(t),
 				},
 			}

--- a/garden-app/server/plant_test.go
+++ b/garden-app/server/plant_test.go
@@ -82,7 +82,7 @@ func TestGetPlant(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pr := PlantsResource{
+			pr := &PlantsResource{
 				GardensResource: &GardensResource{
 					storageClient: setupZonePlantGardenStorage(t),
 				},
@@ -95,7 +95,7 @@ func TestGetPlant(t *testing.T) {
 			router.Route(fmt.Sprintf("/gardens/{%s}/plants/{%s}", gardenPathParam, plantPathParam), func(r chi.Router) {
 				r.Use(pr.gardenContextMiddleware)
 				r.Use(pr.plantContextMiddleware)
-				r.Get("/", pr.getPlant)
+				r.Get("/", get[*PlantResponse](getPlantFromContext))
 			})
 			router.ServeHTTP(w, r)
 
@@ -136,7 +136,7 @@ func TestUpdatePlant(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pr := PlantsResource{
+			pr := &PlantsResource{
 				GardensResource: &GardensResource{
 					storageClient: setupZonePlantGardenStorage(t),
 				},
@@ -184,7 +184,7 @@ func TestEndDatePlant(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pr := PlantsResource{
+			pr := &PlantsResource{
 				GardensResource: &GardensResource{
 					storageClient: storageClient,
 				},
@@ -243,7 +243,7 @@ func TestGetAllPlants(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pr := PlantsResource{
+			pr := &PlantsResource{
 				GardensResource: &GardensResource{
 					storageClient: storageClient,
 				},
@@ -262,11 +262,11 @@ func TestGetAllPlants(t *testing.T) {
 
 			assert.Equal(t, http.StatusOK, w.Code)
 
-			plantJSON, _ := json.Marshal(pr.NewAllPlantsResponse(context.Background(), tt.expected, createExampleGarden()))
+			plantJSON, _ := json.Marshal(pr.NewAllPlantsResponse(tt.expected, createExampleGarden()))
 			// When the expected result contains more than one Plant, on some occasions it might be out of order
 			var reversePlantJSON []byte
 			if len(tt.expected) > 1 {
-				reversePlantJSON, _ = json.Marshal(pr.NewAllPlantsResponse(context.Background(), []*pkg.Plant{tt.expected[1], tt.expected[0]}, &pkg.Garden{}))
+				reversePlantJSON, _ = json.Marshal(pr.NewAllPlantsResponse([]*pkg.Plant{tt.expected[1], tt.expected[0]}, &pkg.Garden{}))
 			}
 			// check HTTP response body
 			actual := strings.TrimSpace(w.Body.String())
@@ -309,7 +309,7 @@ func TestCreatePlant(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pr := PlantsResource{
+			pr := &PlantsResource{
 				GardensResource: &GardensResource{
 					storageClient: setupZonePlantGardenStorage(t),
 				},

--- a/garden-app/server/server.go
+++ b/garden-app/server/server.go
@@ -229,7 +229,7 @@ func NewServer(cfg Config, validateData bool) (*Server, error) {
 		r.Route(fmt.Sprintf("/{%s}", waterSchedulePathParam), func(r chi.Router) {
 			r.Use(waterSchedulesResource.waterScheduleContextMiddleware)
 
-			r.Get("/", waterSchedulesResource.getWaterSchedule)
+			r.Get("/", get[*WaterScheduleResponse](getWaterScheduleFromContext))
 			r.Patch("/", waterSchedulesResource.updateWaterSchedule)
 			r.Delete("/", waterSchedulesResource.endDateWaterSchedule)
 		})

--- a/garden-app/server/server.go
+++ b/garden-app/server/server.go
@@ -168,7 +168,8 @@ func NewServer(cfg Config, validateData bool) (*Server, error) {
 					r.Route(fmt.Sprintf("/{%s}", plantPathParam), func(r chi.Router) {
 						r.Use(plantsResource.plantContextMiddleware)
 
-						r.Get("/", plantsResource.getPlant)
+						r.Get("/", get[*PlantResponse](getPlantFromContext))
+
 						r.Patch("/", plantsResource.updatePlant)
 						r.Delete("/", plantsResource.endDatePlant)
 					})

--- a/garden-app/server/server.go
+++ b/garden-app/server/server.go
@@ -51,7 +51,7 @@ type Server struct {
 	*http.Server
 	quit            chan os.Signal
 	logger          *logrus.Entry
-	gardensResource GardensResource
+	gardensResource *GardensResource
 	worker          *worker.Worker
 }
 
@@ -152,7 +152,7 @@ func NewServer(cfg Config, validateData bool) (*Server, error) {
 		r.Route(fmt.Sprintf("/{%s}", gardenPathParam), func(r chi.Router) {
 			r.Use(gardenResource.gardenContextMiddleware)
 
-			r.Get("/", gardenResource.getGarden)
+			r.Get("/", get[*GardenResponse](getGardenFromContext))
 			r.Patch("/", gardenResource.updateGarden)
 			r.Delete("/", gardenResource.endDateGarden)
 

--- a/garden-app/server/server.go
+++ b/garden-app/server/server.go
@@ -210,7 +210,7 @@ func NewServer(cfg Config, validateData bool) (*Server, error) {
 		r.Route(fmt.Sprintf("/{%s}", weatherClientPathParam), func(r chi.Router) {
 			r.Use(weatherClientsResource.weatherClientContextMiddleware)
 
-			r.Get("/", weatherClientsResource.getWeatherClient)
+			r.Get("/", get[*WeatherClientResponse](getWeatherClientFromContext))
 			r.Patch("/", weatherClientsResource.updateWeatherClient)
 			r.Delete("/", weatherClientsResource.deleteWeatherClient)
 

--- a/garden-app/server/server.go
+++ b/garden-app/server/server.go
@@ -182,7 +182,7 @@ func NewServer(cfg Config, validateData bool) (*Server, error) {
 					r.Route(fmt.Sprintf("/{%s}", zonePathParam), func(r chi.Router) {
 						r.Use(zonesResource.zoneContextMiddleware)
 
-						r.Get("/", zonesResource.getZone)
+						r.Get("/", get[*ZoneResponse](getZoneFromContext))
 						r.Patch("/", zonesResource.updateZone)
 						r.Delete("/", zonesResource.endDateZone)
 

--- a/garden-app/server/weather_clients_responses.go
+++ b/garden-app/server/weather_clients_responses.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -15,11 +14,12 @@ type WeatherClientResponse struct {
 }
 
 // NewWeatherClientResponse creates a new WeatherClientResponse
-func (wcr WeatherClientsResource) NewWeatherClientResponse(_ context.Context, weatherClient *weather.Config, links ...Link) *WeatherClientResponse {
+func (wcr *WeatherClientsResource) NewWeatherClientResponse(weatherClient *weather.Config, links ...Link) *WeatherClientResponse {
 	response := &WeatherClientResponse{
 		Config: weatherClient,
+		Links:  links,
 	}
-	response.Links = append(links,
+	response.Links = append(response.Links,
 		Link{
 			"self",
 			fmt.Sprintf("%s/%s", weatherClientsBasePath, weatherClient.ID),
@@ -41,10 +41,10 @@ type AllWeatherClientsResponse struct {
 }
 
 // NewAllWeatherClientsResponse will create an AllWeatherClientResponse from a list of Zones
-func (wcr WeatherClientsResource) NewAllWeatherClientsResponse(ctx context.Context, weatherClients []*weather.Config) *AllWeatherClientsResponse {
+func (wcr *WeatherClientsResource) NewAllWeatherClientsResponse(weatherClients []*weather.Config) *AllWeatherClientsResponse {
 	weatherClientResponses := []*WeatherClientResponse{}
 	for _, c := range weatherClients {
-		weatherClientResponses = append(weatherClientResponses, wcr.NewWeatherClientResponse(ctx, c))
+		weatherClientResponses = append(weatherClientResponses, wcr.NewWeatherClientResponse(c))
 	}
 	return &AllWeatherClientsResponse{weatherClientResponses}
 }

--- a/garden-app/server/weather_clients_test.go
+++ b/garden-app/server/weather_clients_test.go
@@ -78,7 +78,7 @@ func TestWeatherClientContextMiddleware(t *testing.T) {
 			wcr, _ := NewWeatherClientsResource(storageClient)
 
 			testHandler := func(w http.ResponseWriter, r *http.Request) {
-				wc := getWeatherClientFromContext(r.Context())
+				wc := getWeatherClientFromContext(r.Context()).Config
 				assert.Equal(t, weatherClient, wc)
 				render.Status(r, http.StatusOK)
 			}
@@ -98,10 +98,10 @@ func TestWeatherClientContextMiddleware(t *testing.T) {
 
 func TestGetWeatherClient(t *testing.T) {
 	wcr := WeatherClientsResource{}
-	weatherClientCtx := context.WithValue(context.Background(), weatherClientCtxKey, createExampleWeatherClientConfig())
+	weatherClientCtx := newContextWithWeatherClient(context.Background(), wcr.NewWeatherClientResponse(createExampleWeatherClientConfig()))
 	r := httptest.NewRequest("GET", "/weather_clients", nil).WithContext(weatherClientCtx)
 	w := httptest.NewRecorder()
-	h := http.HandlerFunc(wcr.getWeatherClient)
+	h := http.HandlerFunc(get[*WeatherClientResponse](getWeatherClientFromContext))
 
 	h.ServeHTTP(w, r)
 
@@ -244,7 +244,7 @@ func TestDeleteWeatherClient(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wcr, _ := NewWeatherClientsResource(storageClient)
 
-			weatherClientCtx := context.WithValue(context.Background(), weatherClientCtxKey, tt.weatherClient)
+			weatherClientCtx := newContextWithWeatherClient(context.Background(), &WeatherClientResponse{Config: tt.weatherClient})
 			r := httptest.NewRequest("DELETE", "/weather_clients/"+tt.id, nil).WithContext(weatherClientCtx)
 			r.Header.Add("Content-Type", "application/json")
 			w := httptest.NewRecorder()
@@ -383,7 +383,7 @@ func TestTestWeatherClient(t *testing.T) {
 			wcr, _ := NewWeatherClientsResource(storageClient)
 			weatherClient := createExampleWeatherClientConfig()
 
-			weatherClientCtx := context.WithValue(context.Background(), weatherClientCtxKey, weatherClient)
+			weatherClientCtx := newContextWithWeatherClient(context.Background(), &WeatherClientResponse{Config: weatherClient})
 
 			r := httptest.NewRequest("GET", "/weather_clients/c5cvhpcbcv45e8bp16dg", nil).WithContext(weatherClientCtx)
 			w := httptest.NewRecorder()

--- a/garden-app/server/zone.go
+++ b/garden-app/server/zone.go
@@ -44,7 +44,7 @@ func NewZonesResource(storageClient *storage.Client, influxdbClient influxdb.Cli
 // zoneContextMiddleware middleware is used to load a Zone object from the URL
 // parameters passed through as the request. In case the Zone could not be found,
 // we stop here and return a 404.
-func (zr ZonesResource) zoneContextMiddleware(next http.Handler) http.Handler {
+func (zr *ZonesResource) zoneContextMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -66,7 +66,7 @@ func (zr ZonesResource) zoneContextMiddleware(next http.Handler) http.Handler {
 		}
 		logger.Debugf("found Zone: %+v", zone)
 
-		ctx = newContextWithZone(ctx, zone)
+		ctx = newContextWithZone(ctx, zr.NewZoneResponse(garden, zone))
 		ctx = newContextWithLogger(ctx, logger)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
@@ -75,12 +75,13 @@ func (zr ZonesResource) zoneContextMiddleware(next http.Handler) http.Handler {
 // zoneAction reads a ZoneAction request and uses it to execute one of the actions
 // that is available to run against a Zone. This one endpoint is used for all the different
 // kinds of actions so the action information is carried in the request body
-func (zr ZonesResource) zoneAction(w http.ResponseWriter, r *http.Request) {
+func (zr *ZonesResource) zoneAction(w http.ResponseWriter, r *http.Request) {
 	logger := getLoggerFromContext(r.Context())
 	logger.Info("received request to execute ZoneAction")
 
 	garden := getGardenFromContext(r.Context()).Garden
-	zone := getZoneFromContext(r.Context())
+	zoneResponse := getZoneFromContext(r.Context())
+	zone := zoneResponse.Zone
 
 	action := &ZoneActionRequest{}
 	if err := render.Bind(r, action); err != nil {
@@ -100,27 +101,13 @@ func (zr ZonesResource) zoneAction(w http.ResponseWriter, r *http.Request) {
 	render.DefaultResponder(w, r, nil)
 }
 
-// getZone simply returns the Zone requested by the provided ID
-func (zr ZonesResource) getZone(w http.ResponseWriter, r *http.Request) {
-	logger := getLoggerFromContext(r.Context())
-	logger.Info("received request to get Zone")
-
-	garden := getGardenFromContext(r.Context()).Garden
-	zone := getZoneFromContext(r.Context())
-	logger.Debugf("responding with Zone: %+v", zone)
-
-	if err := render.Render(w, r, zr.NewZoneResponse(r.Context(), garden, zone, excludeWeatherData(r))); err != nil {
-		logger.WithError(err).Error("unable to render ZoneResponse")
-		render.Render(w, r, ErrRender(err))
-	}
-}
-
 // updateZone will change any specified fields of the Zone and save it
-func (zr ZonesResource) updateZone(w http.ResponseWriter, r *http.Request) {
+func (zr *ZonesResource) updateZone(w http.ResponseWriter, r *http.Request) {
 	logger := getLoggerFromContext(r.Context())
 	logger.Info("received request to update Zone")
 
-	zone := getZoneFromContext(r.Context())
+	zoneResponse := getZoneFromContext(r.Context())
+	zone := zoneResponse.Zone
 	request := &UpdateZoneRequest{}
 	garden := getGardenFromContext(r.Context()).Garden
 
@@ -157,13 +144,13 @@ func (zr ZonesResource) updateZone(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := render.Render(w, r, zr.NewZoneResponse(r.Context(), garden, zone, excludeWeatherData(r))); err != nil {
+	if err := render.Render(w, r, zoneResponse); err != nil {
 		logger.WithError(err).Error("unable to render ZoneResponse")
 		render.Render(w, r, ErrRender(err))
 	}
 }
 
-func (zr ZonesResource) waterSchedulesExist(ids []xid.ID) (bool, error) {
+func (zr *ZonesResource) waterSchedulesExist(ids []xid.ID) (bool, error) {
 	for _, id := range ids {
 		ws, err := zr.storageClient.GetWaterSchedule(id)
 		if err != nil {
@@ -178,12 +165,13 @@ func (zr ZonesResource) waterSchedulesExist(ids []xid.ID) (bool, error) {
 }
 
 // endDateZone will mark the Zone's end date as now and save it
-func (zr ZonesResource) endDateZone(w http.ResponseWriter, r *http.Request) {
+func (zr *ZonesResource) endDateZone(w http.ResponseWriter, r *http.Request) {
 	logger := getLoggerFromContext(r.Context())
 	logger.Info("received request to end-date Zone")
 
 	garden := getGardenFromContext(r.Context()).Garden
-	zone := getZoneFromContext(r.Context())
+	zoneResponse := getZoneFromContext(r.Context())
+	zone := zoneResponse.Zone
 	now := time.Now()
 
 	// Unable to delete Zone with associated Plants
@@ -226,14 +214,14 @@ func (zr ZonesResource) endDateZone(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := render.Render(w, r, zr.NewZoneResponse(r.Context(), garden, zone, excludeWeatherData(r))); err != nil {
+	if err := render.Render(w, r, zoneResponse); err != nil {
 		logger.WithError(err).Error("unable to render ZoneResponse")
 		render.Render(w, r, ErrRender(err))
 	}
 }
 
 // getAllZones will return a list of all Zones
-func (zr ZonesResource) getAllZones(w http.ResponseWriter, r *http.Request) {
+func (zr *ZonesResource) getAllZones(w http.ResponseWriter, r *http.Request) {
 	getEndDated := r.URL.Query().Get("end_dated") == "true"
 
 	logger := getLoggerFromContext(r.Context()).WithField("include_end_dated", getEndDated)
@@ -248,14 +236,14 @@ func (zr ZonesResource) getAllZones(w http.ResponseWriter, r *http.Request) {
 	}
 	logger.Debugf("found %d Zones", len(zones))
 
-	if err := render.Render(w, r, zr.NewAllZonesResponse(r.Context(), zones, garden, excludeWeatherData(r))); err != nil {
+	if err := render.Render(w, r, zr.NewAllZonesResponse(zones, garden)); err != nil {
 		logger.WithError(err).Error("unable to render AllZonesResponse")
 		render.Render(w, r, ErrRender(err))
 	}
 }
 
 // createZone will create a new Zone resource
-func (zr ZonesResource) createZone(w http.ResponseWriter, r *http.Request) {
+func (zr *ZonesResource) createZone(w http.ResponseWriter, r *http.Request) {
 	logger := getLoggerFromContext(r.Context())
 	logger.Info("received request to create new Zone")
 
@@ -316,19 +304,20 @@ func (zr ZonesResource) createZone(w http.ResponseWriter, r *http.Request) {
 	}
 
 	render.Status(r, http.StatusCreated)
-	if err := render.Render(w, r, zr.NewZoneResponse(r.Context(), garden, zone, excludeWeatherData(r))); err != nil {
+	if err := render.Render(w, r, zr.NewZoneResponse(garden, zone)); err != nil {
 		logger.WithError(err).Error("unable to render ZoneResponse")
 		render.Render(w, r, ErrRender(err))
 	}
 }
 
 // WaterHistory responds with the Zone's recent water events read from InfluxDB
-func (zr ZonesResource) waterHistory(w http.ResponseWriter, r *http.Request) {
+func (zr *ZonesResource) waterHistory(w http.ResponseWriter, r *http.Request) {
 	logger := getLoggerFromContext(r.Context())
 	logger.Info("received request to get Zone water history")
 
 	garden := getGardenFromContext(r.Context()).Garden
-	zone := getZoneFromContext(r.Context())
+	zoneResponse := getZoneFromContext(r.Context())
+	zone := zoneResponse.Zone
 
 	// Read query parameters and set default values
 	timeRangeString := r.URL.Query().Get("range")
@@ -372,7 +361,7 @@ func (zr ZonesResource) waterHistory(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (zr ZonesResource) getMoisture(ctx context.Context, g *pkg.Garden, z *pkg.Zone) (float64, error) {
+func (zr *ZonesResource) getMoisture(ctx context.Context, g *pkg.Garden, z *pkg.Zone) (float64, error) {
 	defer zr.influxdbClient.Close()
 
 	moisture, err := zr.influxdbClient.GetMoisture(ctx, *z.Position, g.TopicPrefix)
@@ -383,7 +372,7 @@ func (zr ZonesResource) getMoisture(ctx context.Context, g *pkg.Garden, z *pkg.Z
 }
 
 // getWaterHistory gets previous WaterEvents for this Zone from InfluxDB
-func (zr ZonesResource) getWaterHistory(ctx context.Context, zone *pkg.Zone, garden *pkg.Garden, timeRange time.Duration, limit uint64) (result []pkg.WaterHistory, err error) {
+func (zr *ZonesResource) getWaterHistory(ctx context.Context, zone *pkg.Zone, garden *pkg.Garden, timeRange time.Duration, limit uint64) (result []pkg.WaterHistory, err error) {
 	defer zr.influxdbClient.Close()
 
 	history, err := zr.influxdbClient.GetWaterHistory(ctx, *zone.Position, garden.TopicPrefix, timeRange, limit)

--- a/garden-app/server/zone.go
+++ b/garden-app/server/zone.go
@@ -57,7 +57,7 @@ func (zr ZonesResource) zoneContextMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		garden := getGardenFromContext(ctx)
+		garden := getGardenFromContext(r.Context()).Garden
 		zone := garden.Zones[zoneID]
 		if zone == nil {
 			logger.Info("zone not found")
@@ -79,7 +79,7 @@ func (zr ZonesResource) zoneAction(w http.ResponseWriter, r *http.Request) {
 	logger := getLoggerFromContext(r.Context())
 	logger.Info("received request to execute ZoneAction")
 
-	garden := getGardenFromContext(r.Context())
+	garden := getGardenFromContext(r.Context()).Garden
 	zone := getZoneFromContext(r.Context())
 
 	action := &ZoneActionRequest{}
@@ -105,7 +105,7 @@ func (zr ZonesResource) getZone(w http.ResponseWriter, r *http.Request) {
 	logger := getLoggerFromContext(r.Context())
 	logger.Info("received request to get Zone")
 
-	garden := getGardenFromContext(r.Context())
+	garden := getGardenFromContext(r.Context()).Garden
 	zone := getZoneFromContext(r.Context())
 	logger.Debugf("responding with Zone: %+v", zone)
 
@@ -122,7 +122,7 @@ func (zr ZonesResource) updateZone(w http.ResponseWriter, r *http.Request) {
 
 	zone := getZoneFromContext(r.Context())
 	request := &UpdateZoneRequest{}
-	garden := getGardenFromContext(r.Context())
+	garden := getGardenFromContext(r.Context()).Garden
 
 	// Read the request body into existing zone to overwrite fields
 	if err := render.Bind(r, request); err != nil {
@@ -182,7 +182,7 @@ func (zr ZonesResource) endDateZone(w http.ResponseWriter, r *http.Request) {
 	logger := getLoggerFromContext(r.Context())
 	logger.Info("received request to end-date Zone")
 
-	garden := getGardenFromContext(r.Context())
+	garden := getGardenFromContext(r.Context()).Garden
 	zone := getZoneFromContext(r.Context())
 	now := time.Now()
 
@@ -239,7 +239,7 @@ func (zr ZonesResource) getAllZones(w http.ResponseWriter, r *http.Request) {
 	logger := getLoggerFromContext(r.Context()).WithField("include_end_dated", getEndDated)
 	logger.Info("received request to get all Zones")
 
-	garden := getGardenFromContext(r.Context())
+	garden := getGardenFromContext(r.Context()).Garden
 	zones := []*pkg.Zone{}
 	for _, z := range garden.Zones {
 		if getEndDated || (z.EndDate == nil || z.EndDate.After(time.Now())) {
@@ -269,7 +269,7 @@ func (zr ZonesResource) createZone(w http.ResponseWriter, r *http.Request) {
 	zone := request.Zone
 	logger.Debugf("request to create Zone: %+v", zone)
 
-	garden := getGardenFromContext(r.Context())
+	garden := getGardenFromContext(r.Context()).Garden
 
 	// Validate that adding a Zone does not exceed Garden.MaxZones
 	if garden.NumZones()+1 > *garden.MaxZones {
@@ -327,7 +327,7 @@ func (zr ZonesResource) waterHistory(w http.ResponseWriter, r *http.Request) {
 	logger := getLoggerFromContext(r.Context())
 	logger.Info("received request to get Zone water history")
 
-	garden := getGardenFromContext(r.Context())
+	garden := getGardenFromContext(r.Context()).Garden
 	zone := getZoneFromContext(r.Context())
 
 	// Read query parameters and set default values

--- a/garden-app/server/zone_test.go
+++ b/garden-app/server/zone_test.go
@@ -94,7 +94,7 @@ func TestZoneContextMiddleware(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			garden := createExampleGarden()
 			garden.Zones[zone.ID] = tt.zone
-			ctx := context.WithValue(context.Background(), gardenCtxKey, garden)
+			ctx := newContextWithGarden(context.Background(), &GardenResponse{Garden: garden})
 			r := httptest.NewRequest("GET", tt.path, nil).WithContext(ctx)
 			w := httptest.NewRecorder()
 
@@ -324,7 +324,7 @@ func TestGetZone(t *testing.T) {
 			garden := createExampleGarden()
 			zone := createExampleZone()
 
-			gardenCtx := context.WithValue(context.Background(), gardenCtxKey, garden)
+			gardenCtx := newContextWithGarden(context.Background(), &GardenResponse{Garden: garden})
 			zoneCtx := context.WithValue(gardenCtx, zoneCtxKey, zone)
 			r := httptest.NewRequest("GET", fmt.Sprintf("/zone?exclude_weather_data=%t", tt.excludeWeatherData), nil).WithContext(zoneCtx)
 			w := httptest.NewRecorder()
@@ -402,7 +402,7 @@ func TestZoneAction(t *testing.T) {
 			garden := createExampleGarden()
 			zone := createExampleZone()
 
-			gardenCtx := context.WithValue(context.Background(), gardenCtxKey, garden)
+			gardenCtx := newContextWithGarden(context.Background(), &GardenResponse{Garden: garden})
 			zoneCtx := context.WithValue(gardenCtx, zoneCtxKey, zone)
 			r := httptest.NewRequest("POST", "/zone", strings.NewReader(tt.body)).WithContext(zoneCtx)
 			r.Header.Add("Content-Type", "application/json")
@@ -467,7 +467,7 @@ func TestUpdateZone(t *testing.T) {
 			garden := createExampleGarden()
 			zone := createExampleZone()
 
-			gardenCtx := context.WithValue(context.Background(), gardenCtxKey, garden)
+			gardenCtx := newContextWithGarden(context.Background(), &GardenResponse{Garden: garden})
 			zoneCtx := context.WithValue(gardenCtx, zoneCtxKey, zone)
 			r := httptest.NewRequest("PATCH", "/zone", strings.NewReader(tt.body)).WithContext(zoneCtx)
 			r.Header.Add("Content-Type", "application/json")
@@ -528,7 +528,7 @@ func TestEndDateZone(t *testing.T) {
 			}
 
 			garden := createExampleGarden()
-			gardenCtx := context.WithValue(context.Background(), gardenCtxKey, garden)
+			gardenCtx := newContextWithGarden(context.Background(), &GardenResponse{Garden: garden})
 			zoneCtx := context.WithValue(gardenCtx, zoneCtxKey, tt.zone)
 			r := httptest.NewRequest("DELETE", "/zone", nil).WithContext(zoneCtx)
 			r.Header.Add("Content-Type", "application/json")
@@ -567,7 +567,7 @@ func TestGetAllZones(t *testing.T) {
 	garden.Zones[zone.ID] = zone
 	garden.Zones[endDatedZone.ID] = endDatedZone
 
-	gardenCtx := context.WithValue(context.Background(), gardenCtxKey, garden)
+	gardenCtx := newContextWithGarden(context.Background(), &GardenResponse{Garden: garden})
 
 	tests := []struct {
 		name      string
@@ -728,7 +728,7 @@ func TestCreateZone(t *testing.T) {
 			zr.worker.StartAsync()
 			defer zr.worker.Stop()
 
-			gardenCtx := context.WithValue(context.Background(), gardenCtxKey, tt.garden)
+			gardenCtx := newContextWithGarden(context.Background(), &GardenResponse{Garden: tt.garden})
 			r := httptest.NewRequest("POST", "/zone", strings.NewReader(tt.body)).WithContext(gardenCtx)
 			r.Header.Add("Content-Type", "application/json")
 			w := httptest.NewRecorder()
@@ -832,7 +832,7 @@ func TestWaterHistory(t *testing.T) {
 			garden := createExampleGarden()
 			zone := createExampleZone()
 
-			gardenCtx := context.WithValue(context.Background(), gardenCtxKey, garden)
+			gardenCtx := newContextWithGarden(context.Background(), &GardenResponse{Garden: garden})
 			zoneCtx := context.WithValue(gardenCtx, zoneCtxKey, zone)
 			r := httptest.NewRequest("GET", fmt.Sprintf("/history%s", tt.queryParams), nil).WithContext(zoneCtx)
 			w := httptest.NewRecorder()


### PR DESCRIPTION
The simple GET handlers are identical for all resources so it is a good opportunity to make better use of the `renderer.Render` interface and generic type parameters.