### PR TITLE
Allow creating a Zone without WaterSchedules

### DIFF
--- a/garden-app/pkg/zone.go
+++ b/garden-app/pkg/zone.go
@@ -133,9 +133,6 @@ func (z *Zone) Bind(r *http.Request) error {
 		if z.Position == nil {
 			return errors.New("missing required position field")
 		}
-		if len(z.WaterScheduleIDs) == 0 {
-			return errors.New("missing required water_schedule_ids field")
-		}
 		if z.Name == "" {
 			return errors.New("missing required name field")
 		}

--- a/garden-app/server/zone_test.go
+++ b/garden-app/server/zone_test.go
@@ -1029,14 +1029,6 @@ func TestZoneRequest(t *testing.T) {
 			"missing required position field",
 		},
 		{
-			"EmptyWaterScheduleIDError",
-			&pkg.Zone{
-				Name:     "zone",
-				Position: &pos,
-			},
-			"missing required water_schedule_ids field",
-		},
-		{
 			"EmptyNameError",
 			&pkg.Zone{
 				Position:         &pos,


### PR DESCRIPTION
- This will enable a type of Zone that is only used for "on-demand" or manual watering
- It also allows another way of disabling a Zone temporarily by removing any schedules