### PR TITLE
Notify for Garden downtime

### DIFF
--- a/garden-app/clock/clock.go
+++ b/garden-app/clock/clock.go
@@ -7,6 +7,10 @@ import (
 	"github.com/go-co-op/gocron"
 )
 
+type Timer interface {
+	Reset(d time.Duration) bool
+}
+
 // Clock allows mocking time
 type Clock struct {
 	clock.Clock
@@ -40,4 +44,8 @@ func MockTime() *clock.Mock {
 // Reset returns the DefaultClock to real time
 func Reset() {
 	DefaultClock = Clock{clock.New()}
+}
+
+func AfterFunc(d time.Duration, f func()) Timer {
+	return DefaultClock.AfterFunc(d, f)
 }

--- a/garden-app/pkg/garden.go
+++ b/garden-app/pkg/garden.go
@@ -40,9 +40,9 @@ type Garden struct {
 }
 
 type NotificationSettings struct {
-	ControllerStartup bool          `json:"controller_startup" yaml:"controller_startup"`
-	LightSchedule     bool          `json:"light_schedule" yaml:"light_schedule"`
-	Downtime          time.Duration `json:"downtime" yaml:"downtime"`
+	ControllerStartup bool      `json:"controller_startup" yaml:"controller_startup"`
+	LightSchedule     bool      `json:"light_schedule" yaml:"light_schedule"`
+	Downtime          *Duration `json:"downtime" yaml:"downtime"`
 }
 
 func (g *Garden) GetVersion() uint {

--- a/garden-app/pkg/garden.go
+++ b/garden-app/pkg/garden.go
@@ -40,8 +40,9 @@ type Garden struct {
 }
 
 type NotificationSettings struct {
-	ControllerStartup bool `json:"controller_startup" yaml:"controller_startup"`
-	LightSchedule     bool `json:"light_schedule" yaml:"light_schedule"`
+	ControllerStartup bool          `json:"controller_startup" yaml:"controller_startup"`
+	LightSchedule     bool          `json:"light_schedule" yaml:"light_schedule"`
+	Downtime          time.Duration `json:"downtime" yaml:"downtime"`
 }
 
 func (g *Garden) GetVersion() uint {
@@ -180,6 +181,7 @@ func (g *Garden) Patch(newGarden *Garden) *babyapi.ErrResponse {
 		}
 		g.NotificationSettings.ControllerStartup = newGarden.NotificationSettings.ControllerStartup
 		g.NotificationSettings.LightSchedule = newGarden.NotificationSettings.LightSchedule
+		g.NotificationSettings.Downtime = newGarden.NotificationSettings.Downtime
 	}
 
 	return nil

--- a/garden-app/pkg/notifications/fake/fake.go
+++ b/garden-app/pkg/notifications/fake/fake.go
@@ -70,7 +70,7 @@ func Messages() []Message {
 	return result
 }
 
-func ResetLastMessage() {
+func Reset() {
 	messagesMtx.Lock()
 	messages = []Message{}
 	messagesMtx.Unlock()

--- a/garden-app/server/templates/garden_modal.html
+++ b/garden-app/server/templates/garden_modal.html
@@ -161,7 +161,7 @@ TODO: add UI for new downtime notifications
 
             <div class="uk-margin">
                 <label class="uk-form-label" for="garden-config-temp-hum-interval">Temperature/Humidity Sensor Interval</label>
-                <input id="garden-config-temp-hum-interval" class="uk-input" value="{{ if .ControllerConfig.TemperatureHumidityInterval }}{{ .ControllerConfig.TemperatureHumidityInterval }}{{ end }}" placeholder="Temperature/Humidity Sensor Interval"
+                <input id="garden-config-temp-hum-interval" class="uk-input" value="{{ if and .ControllerConfig .ControllerConfig.TemperatureHumidityInterval }}{{ .ControllerConfig.TemperatureHumidityInterval }}{{ end }}" placeholder="Temperature/Humidity Sensor Interval"
                     name="ControllerConfig.TemperatureHumidityInterval">
             </div>
             {{ end }}

--- a/garden-app/server/templates/garden_modal.html
+++ b/garden-app/server/templates/garden_modal.html
@@ -1,3 +1,5 @@
+TODO: add UI for new downtime notifications
+
 {{ define "GardenModal" }}
 <div id="modal" class="uk-modal" style="display:block;">
     <div class="uk-modal-dialog uk-modal-body">
@@ -94,6 +96,19 @@
                             </div>
                         </label>
                     </div>
+                    <div class="uk-width-1-2@m">
+                        <label>
+                            <div class="uk-inline uk-margin-small-top">
+                                Downtime Notification
+                                <span class="uk-margin-small-right" uk-icon="icon: info; ratio: 0.75"></span>
+                                <div uk-dropdown="pos: right-center">
+                                    Enable notifications when the controller fails to publish health checks for the specified duration
+                                </div>
+                                <input class="uk-input" type="text" name="NotificationSettings.Downtime"
+                                    value="{{ if and .NotificationSettings .NotificationSettings.Downtime }}{{ .NotificationSettings.Downtime }}{{ end }}">
+                            </div>
+                        </label>
+                </div>
                 </div>
             </div>
             

--- a/garden-app/worker/down_notification.go
+++ b/garden-app/worker/down_notification.go
@@ -29,17 +29,17 @@ func (w *Worker) handleHealthMessage(topic, payload string) {
 	}
 
 	downtime := garden.GetNotificationSettings().Downtime
-	if downtime <= 0 {
+	if downtime == nil || downtime.Duration <= 0 {
 		return
 	}
 
 	timer, ok := w.downTimers[topic]
 	if !ok {
-		timer := w.newDownTimer(downtime, topic)
+		timer := w.newDownTimer(downtime.Duration, topic)
 		w.downTimers[topic] = timer
 		logger.Info("created new timer")
 	} else {
-		timer.Reset(downtime)
+		timer.Reset(downtime.Duration)
 		logger.Info("reset timer")
 	}
 }
@@ -71,7 +71,7 @@ func (w *Worker) handleDowntimeNotification(topic string) error {
 	}
 
 	downtime := garden.GetNotificationSettings().Downtime
-	if downtime <= 0 {
+	if downtime == nil || downtime.Duration <= 0 {
 		return nil
 	}
 

--- a/garden-app/worker/down_notification.go
+++ b/garden-app/worker/down_notification.go
@@ -1,0 +1,91 @@
+package worker
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/calvinmclean/automated-garden/garden-app/clock"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+)
+
+func (w *Worker) healthMessageHandler(_ mqtt.Client, msg mqtt.Message) {
+	w.handleHealthMessage(msg.Topic(), string(msg.Payload()))
+}
+
+func (w *Worker) handleHealthMessage(topic, payload string) {
+	logger := w.logger.With("topic", topic)
+
+	if !checkHealthMessage(topic, payload) {
+		logger.Warn("unexpected message from controller", "message", payload)
+		return
+	}
+	logger.Info("received message", "message", payload)
+
+	garden, err := w.getGardenForTopic(topic)
+	if err != nil {
+		logger.Error("error getting Garden for health topic", "error", err)
+		return
+	}
+
+	downtime := garden.GetNotificationSettings().Downtime
+	if downtime <= 0 {
+		return
+	}
+
+	timer, ok := w.downTimers[topic]
+	if !ok {
+		timer := w.newDownTimer(downtime, topic)
+		w.downTimers[topic] = timer
+		logger.Info("created new timer")
+	} else {
+		timer.Reset(downtime)
+		logger.Info("reset timer")
+	}
+}
+
+func (w *Worker) newDownTimer(d time.Duration, topic string) clock.Timer {
+	return clock.AfterFunc(d, func() {
+		// make Worker wait for this before shutdown
+		w.downtimeWG.Add(1)
+		defer w.downtimeWG.Done()
+
+		logger := w.logger.With("topic", topic)
+
+		err := w.handleDowntimeNotification(topic)
+		if err != nil {
+			logger.Error("failed to handle downtime timer", "error", err)
+			return
+		}
+
+		logger.Info("successfully sent down notification")
+	})
+}
+
+// handleDowntimeNotification re-reads the Garden from storage in case it's configuration changed
+// after this goroutine was started
+func (w *Worker) handleDowntimeNotification(topic string) error {
+	garden, err := w.getGardenForTopic(topic)
+	if err != nil {
+		return err
+	}
+
+	downtime := garden.GetNotificationSettings().Downtime
+	if downtime <= 0 {
+		return nil
+	}
+
+	title := fmt.Sprintf("%s is down", garden.Name)
+	msg := fmt.Sprintf("Garden has been down for > %s", downtime.String())
+
+	return w.sendNotificationForGarden(garden, title, msg)
+}
+
+// message format: 'health garden="{{ TopicPrefix }}"'
+func checkHealthMessage(topic, msg string) bool {
+	topicPrefix, err := getTopicPrefix(topic)
+	if err != nil {
+		return false
+	}
+	return msg == fmt.Sprintf(`health garden="%s"`, topicPrefix)
+}

--- a/garden-app/worker/down_notification_test.go
+++ b/garden-app/worker/down_notification_test.go
@@ -1,0 +1,144 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/calvinmclean/automated-garden/garden-app/clock"
+	"github.com/calvinmclean/automated-garden/garden-app/pkg"
+	"github.com/calvinmclean/automated-garden/garden-app/pkg/notifications"
+	"github.com/calvinmclean/automated-garden/garden-app/pkg/notifications/fake"
+	"github.com/calvinmclean/automated-garden/garden-app/pkg/storage"
+	"github.com/calvinmclean/babyapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testDowntimeThreshold = 5 * time.Minute
+
+func TestCheckHealthMessage(t *testing.T) {
+	tests := []struct {
+		topic    string
+		message  string
+		expected bool
+	}{
+		{
+			"/",
+			`health garden=""`,
+			false,
+		},
+		{
+			"topic/data/health",
+			`health garden="topic"`,
+			true,
+		},
+		{
+			"topic/suffix",
+			`health garden="topic"`,
+			false,
+		},
+		{
+			"topic/data/health",
+			`bad message`,
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.message, func(t *testing.T) {
+			assert.Equal(t, tt.expected, checkHealthMessage(tt.topic, tt.message))
+		})
+	}
+}
+
+func TestHandleHealthMessage(t *testing.T) {
+	storageClient, err := storage.NewClient(storage.Config{
+		Driver: "hashmap",
+	})
+	require.NoError(t, err)
+
+	garden := &pkg.Garden{
+		Name:                 "MyGarden",
+		ID:                   babyapi.NewID(),
+		TopicPrefix:          "garden",
+		NotificationClientID: nil,
+		NotificationSettings: &pkg.NotificationSettings{
+			Downtime: testDowntimeThreshold,
+		},
+	}
+	err = storageClient.Gardens.Set(context.Background(), garden)
+	require.NoError(t, err)
+
+	clock.Reset()
+	defer clock.Reset()
+
+	t.Run("CreateNotificationClient", func(t *testing.T) {
+		nc := &notifications.Client{
+			ID:      babyapi.NewID(),
+			Type:    "fake",
+			Options: map[string]any{},
+		}
+
+		err := storageClient.NotificationClientConfigs.Set(context.Background(), nc)
+		require.NoError(t, err)
+
+		ncID := nc.GetID()
+		apiErr := garden.Patch(&pkg.Garden{NotificationClientID: &ncID})
+		require.Nil(t, apiErr)
+		err = storageClient.Gardens.Set(context.Background(), garden)
+		require.NoError(t, err)
+	})
+
+	t.Run("NotifyDueToDowntime", func(t *testing.T) {
+		defer fake.Reset()
+		mockClock := clock.MockTime()
+
+		var logBuffer bytes.Buffer
+		w := NewWorker(storageClient, nil, nil, slog.New(slog.NewTextHandler(&logBuffer, nil)))
+
+		topic := "garden/data/health"
+		w.handleHealthMessage(topic, `health garden="garden"`)
+
+		mockClock.Add(testDowntimeThreshold + 1*time.Second)
+
+		w.Stop()
+
+		lastMessage := fake.LastMessage()
+		assert.Equal(t, "MyGarden is down", lastMessage.Title)
+		assert.Equal(t, "Garden has been down for > 5m0s", lastMessage.Message)
+
+		logs := logBuffer.String()
+		assert.Contains(t, logs, `msg="successfully sent down notification" source=worker topic=garden/data/health`)
+		assert.Contains(t, logs, `msg="created new timer" source=worker topic=garden/data/health`)
+	})
+
+	t.Run("TimerIsReset", func(t *testing.T) {
+		defer fake.Reset()
+		mockClock := clock.MockTime()
+
+		var logBuffer bytes.Buffer
+		w := NewWorker(storageClient, nil, nil, slog.New(slog.NewTextHandler(&logBuffer, nil)))
+
+		topic := "garden/data/health"
+
+		// send initial message
+		w.handleHealthMessage(topic, `health garden="garden"`)
+
+		// send another message before threshold
+		mockClock.Add(testDowntimeThreshold - 1*time.Second)
+		w.handleHealthMessage(topic, `health garden="garden"`)
+
+		// now jump forward a bit to after the initial threshold
+		mockClock.Add(2 * time.Second)
+
+		w.Stop()
+
+		assert.Empty(t, fake.Messages())
+
+		logs := logBuffer.String()
+		assert.Contains(t, logs, `msg="reset timer" source=worker topic=garden/data/health`)
+	})
+}

--- a/garden-app/worker/notification_handler_utils_test.go
+++ b/garden-app/worker/notification_handler_utils_test.go
@@ -1,7 +1,6 @@
 package worker
 
 import (
-	"log/slog"
 	"testing"
 
 	"github.com/calvinmclean/automated-garden/garden-app/pkg"
@@ -11,8 +10,7 @@ import (
 func TestSendNotificationForGarden(t *testing.T) {
 	t.Run("GardenWithoutNotificationClientID", func(t *testing.T) {
 		w := &Worker{}
-		logger := &slog.Logger{}
-		err := w.sendNotificationForGarden(&pkg.Garden{}, "title", "message", logger)
+		err := w.sendNotificationForGarden(&pkg.Garden{}, "title", "message")
 		assert.Error(t, err)
 		assert.Equal(t, "garden does not have notification client", err.Error())
 	})

--- a/garden-app/worker/scheduler_test.go
+++ b/garden-app/worker/scheduler_test.go
@@ -116,6 +116,9 @@ func TestScheduleWaterAction(t *testing.T) {
 	assert.NoError(t, err)
 	defer weather.ResetCache()
 
+	clock.Reset()
+	defer clock.Reset()
+
 	garden := createExampleGarden()
 	zone := createExampleZone()
 
@@ -201,7 +204,7 @@ func TestScheduleWaterActionGardenHealthNotification(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fake.ResetLastMessage()
+			fake.Reset()
 
 			storageClient, err := storage.NewClient(storage.Config{
 				Driver: "hashmap",
@@ -280,7 +283,7 @@ func TestScheduleWaterActionWithErrorNotification(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fake.ResetLastMessage()
+			fake.Reset()
 
 			storageClient, err := storage.NewClient(storage.Config{
 				Driver: "hashmap",
@@ -640,7 +643,7 @@ func TestScheduleLightActions(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				fake.ResetLastMessage()
+				fake.Reset()
 
 				storageClient, err := storage.NewClient(storage.Config{
 					Driver: "hashmap",
@@ -724,7 +727,7 @@ func TestScheduleLightActions(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				fake.ResetLastMessage()
+				fake.Reset()
 
 				storageClient, err := storage.NewClient(storage.Config{
 					Driver: "hashmap",

--- a/garden-app/worker/startup_notification_handler.go
+++ b/garden-app/worker/startup_notification_handler.go
@@ -9,13 +9,13 @@ import (
 )
 
 func (w *Worker) handleGardenStartupMessage(_ mqtt.Client, msg mqtt.Message) {
-	err := w.getGardenAndSendMessage(msg.Topic(), string(msg.Payload()))
+	err := w.getGardenAndSendStartupMessage(msg.Topic(), string(msg.Payload()))
 	if err != nil {
 		w.logger.With("topic", msg.Topic(), "error", err).Error("error handling message")
 	}
 }
 
-func (w *Worker) getGardenAndSendMessage(topic string, payload string) error {
+func (w *Worker) getGardenAndSendStartupMessage(topic string, payload string) error {
 	logger := w.logger.With("topic", topic)
 
 	msg := parseStartupMessage(payload)
@@ -44,7 +44,7 @@ func (w *Worker) sendGardenStartupMessage(garden *pkg.Garden, topic string, msg 
 	}
 
 	title := fmt.Sprintf("%s connected", garden.Name)
-	return w.sendNotificationForGarden(garden, title, msg, logger)
+	return w.sendNotificationForGarden(garden, title, msg)
 }
 
 func parseStartupMessage(msg string) string {

--- a/garden-app/worker/startup_notification_handler_test.go
+++ b/garden-app/worker/startup_notification_handler_test.go
@@ -72,7 +72,7 @@ func TestGetGardenAndSendMessage_WarnLogs(t *testing.T) {
 			w := &Worker{
 				logger: slog.New(slog.NewTextHandler(&logBuffer, nil)),
 			}
-			err := w.getGardenAndSendMessage(tt.topic, tt.payload)
+			err := w.getGardenAndSendStartupMessage(tt.topic, tt.payload)
 			require.NoError(t, err)
 
 			// Remove the time attribute before asserting

--- a/garden-app/worker/water_notification_handler.go
+++ b/garden-app/worker/water_notification_handler.go
@@ -44,7 +44,7 @@ func (w *Worker) doWaterCompleteMessage(topic string, payload []byte) error {
 
 	title := fmt.Sprintf("%s finished watering", zone.Name)
 	message := fmt.Sprintf("watered for %s", waterDuration.String())
-	return w.sendNotificationForGarden(garden, title, message, logger)
+	return w.sendNotificationForGarden(garden, title, message)
 }
 
 func parseWaterMessage(msg []byte) (int, time.Duration, error) {


### PR DESCRIPTION
Subscribe to MQTT health checks from controllers. Use `AfterFunc` to alert if down for the specified amount of time.