### PR TITLE
Improve WeatherScaler to be more configurable

### DIFF
--- a/garden-app/integration_tests/main_test.go
+++ b/garden-app/integration_tests/main_test.go
@@ -409,11 +409,13 @@ func WaterScheduleTests(t *testing.T) {
 		var ws2 server.WaterScheduleResponse
 		status, err = makeRequest(http.MethodPatch, "/water_schedules/"+waterScheduleID, pkg.WaterSchedule{
 			WeatherControl: &weather.Control{
-				Rain: &weather.ScaleControl{
-					BaselineValue: pointer[float32](0),
-					Factor:        pointer[float32](0),
-					Range:         pointer[float32](25.4),
+				Rain: &weather.WeatherScaler{
 					ClientID:      weatherClientWithRain,
+					Interpolation: weather.Linear,
+					InputMin:      pointer[float64](0),
+					InputMax:      pointer[float64](25.4),
+					FactorMin:     pointer[float64](1.0),
+					FactorMax:     pointer[float64](0.0),
 				},
 			},
 		}, &ws2)

--- a/garden-app/pkg/storage/migration_test.go
+++ b/garden-app/pkg/storage/migration_test.go
@@ -179,8 +179,6 @@ func TestWeatherScalerMigration(t *testing.T) {
 	var weatherControl string
 	err = db.QueryRow("SELECT weather_control FROM water_schedules WHERE id = 'ws_rain_only'").Scan(&weatherControl)
 	require.NoError(t, err)
-	// SQLite stores booleans as 1/0 in JSON
-	assert.Contains(t, weatherControl, `"enabled":1`)
 	assert.Contains(t, weatherControl, `"interpolation":"linear"`)
 	assert.Contains(t, weatherControl, `"input_min":0`)
 	assert.Contains(t, weatherControl, `"input_max":25.4`)
@@ -195,7 +193,6 @@ func TestWeatherScalerMigration(t *testing.T) {
 	// Verify temperature-only conversion
 	err = db.QueryRow("SELECT weather_control FROM water_schedules WHERE id = 'ws_temp_only'").Scan(&weatherControl)
 	require.NoError(t, err)
-	assert.Contains(t, weatherControl, `"enabled":1`)
 	assert.Contains(t, weatherControl, `"interpolation":"linear"`)
 	assert.Contains(t, weatherControl, `"input_min":20`)   // 30 - 10 = 20
 	assert.Contains(t, weatherControl, `"input_max":40`)   // 30 + 10 = 40

--- a/garden-app/pkg/storage/migration_test.go
+++ b/garden-app/pkg/storage/migration_test.go
@@ -94,6 +94,155 @@ func TestNotificationClientURLMigration(t *testing.T) {
 	assert.Equal(t, 0, colCount, "type and options columns should be dropped")
 }
 
+func TestWeatherScalerMigration(t *testing.T) {
+	db, err := sql.Open("sqlite", "file:weatherMigrateTest?mode=memory&cache=shared")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Create water_schedules table with schema as it was before migration 5
+	_, err = db.Exec(`
+		CREATE TABLE water_schedules (
+			id VARCHAR(20) PRIMARY KEY,
+			name TEXT,
+			description TEXT,
+			duration INT NOT NULL,
+			interval INT NOT NULL,
+			start_date DATETIME NOT NULL,
+			start_time VARCHAR(14) NOT NULL,
+			end_date DATETIME,
+			active_period_start_month TEXT,
+			active_period_end_month TEXT,
+			weather_control TEXT,
+			notification_client_id VARCHAR(20)
+		)
+	`)
+	require.NoError(t, err)
+
+	// Create weather_clients table (schema before migration 2 adds 'name' column)
+	_, err = db.Exec(`
+		CREATE TABLE weather_clients (
+			id VARCHAR(20) PRIMARY KEY,
+			type TEXT NOT NULL,
+			options JSON NOT NULL
+		)
+	`)
+	require.NoError(t, err)
+
+	// Insert test data with old ScaleControl format
+	// Rain control: baseline_value=0, factor=0, range=25.4, client_id=client1
+	// Expected: input_min=0, input_max=25.4, factor_min=1.0, factor_max=1.0
+	_, err = db.Exec(`
+		INSERT INTO water_schedules (id, duration, interval, start_date, start_time, weather_control)
+		VALUES ('ws_rain_only', 3600, 86400, '2024-01-01', '08:00:00Z',
+			'{"rain_control":{"baseline_value":0,"factor":0,"range":25.4,"client_id":"client1"}}')
+	`)
+	require.NoError(t, err)
+
+	// Insert test data with old ScaleControl format
+	// Temperature control: baseline_value=30, factor=0.5, range=10, client_id=client2
+	// Expected: input_min=20, input_max=40, factor_min=0.5, factor_max=1.5
+	_, err = db.Exec(`
+		INSERT INTO water_schedules (id, duration, interval, start_date, start_time, weather_control)
+		VALUES ('ws_temp_only', 3600, 86400, '2024-01-01', '08:00:00Z',
+			'{"temperature_control":{"baseline_value":30,"factor":0.5,"range":10,"client_id":"client2"}}')
+	`)
+	require.NoError(t, err)
+
+	// Insert test data with both controls
+	_, err = db.Exec(`
+		INSERT INTO water_schedules (id, duration, interval, start_date, start_time, weather_control)
+		VALUES ('ws_both', 3600, 86400, '2024-01-01', '08:00:00Z',
+			'{"rain_control":{"baseline_value":5,"factor":0.2,"range":20,"client_id":"client1"},"temperature_control":{"baseline_value":25,"factor":0.3,"range":8,"client_id":"client2"}}')
+	`)
+	require.NoError(t, err)
+
+	// Insert test data with NULL weather_control
+	_, err = db.Exec(`
+		INSERT INTO water_schedules (id, duration, interval, start_date, start_time, weather_control)
+		VALUES ('ws_no_weather', 3600, 86400, '2024-01-01', '08:00:00Z', NULL)
+	`)
+	require.NoError(t, err)
+
+	driver, err := sqlite3.WithInstance(db, &sqlite3.Config{})
+	require.NoError(t, err)
+
+	migrations, err := iofs.New(migrationsFS, "migrations")
+	require.NoError(t, err)
+
+	m, err := migrate.NewWithInstance("iofs", migrations, "sqlite3", driver)
+	require.NoError(t, err)
+
+	err = m.Up()
+	require.NoError(t, err)
+
+	// Verify rain-only conversion
+	var weatherControl string
+	err = db.QueryRow("SELECT weather_control FROM water_schedules WHERE id = 'ws_rain_only'").Scan(&weatherControl)
+	require.NoError(t, err)
+	// SQLite stores booleans as 1/0 in JSON
+	assert.Contains(t, weatherControl, `"enabled":1`)
+	assert.Contains(t, weatherControl, `"interpolation":"linear"`)
+	assert.Contains(t, weatherControl, `"input_min":0`)
+	assert.Contains(t, weatherControl, `"input_max":25.4`)
+	assert.Contains(t, weatherControl, `"factor_min":1`) // 1.0 - 0.0 = 1.0
+	assert.Contains(t, weatherControl, `"factor_max":1`)
+	assert.Contains(t, weatherControl, `"client_id":"client1"`)
+	// Old fields should not exist
+	assert.NotContains(t, weatherControl, `"baseline_value"`)
+	assert.NotContains(t, weatherControl, `"factor":`)
+	assert.NotContains(t, weatherControl, `"range":`)
+
+	// Verify temperature-only conversion
+	err = db.QueryRow("SELECT weather_control FROM water_schedules WHERE id = 'ws_temp_only'").Scan(&weatherControl)
+	require.NoError(t, err)
+	assert.Contains(t, weatherControl, `"enabled":1`)
+	assert.Contains(t, weatherControl, `"interpolation":"linear"`)
+	assert.Contains(t, weatherControl, `"input_min":20`)   // 30 - 10 = 20
+	assert.Contains(t, weatherControl, `"input_max":40`)   // 30 + 10 = 40
+	assert.Contains(t, weatherControl, `"factor_min":0.5`) // 1.0 - 0.5 = 0.5
+	assert.Contains(t, weatherControl, `"factor_max":1.5`) // 1.0 + 0.5 = 1.5
+	assert.Contains(t, weatherControl, `"client_id":"client2"`)
+
+	// Verify both controls conversion
+	err = db.QueryRow("SELECT weather_control FROM water_schedules WHERE id = 'ws_both'").Scan(&weatherControl)
+	require.NoError(t, err)
+	// Rain: baseline=5, range=20 -> input_min=5, input_max=25, factor_min=0.8, factor_max=1.0
+	assert.Contains(t, weatherControl, `"input_min":5`)
+	assert.Contains(t, weatherControl, `"input_max":25`)
+	assert.Contains(t, weatherControl, `"factor_min":0.8`) // 1.0 - 0.2 = 0.8
+	// Temp: baseline=25, range=8 -> input_min=17, input_max=33, factor_min=0.7, factor_max=1.3
+	assert.Contains(t, weatherControl, `"input_min":17`)   // 25 - 8 = 17
+	assert.Contains(t, weatherControl, `"input_max":33`)   // 25 + 8 = 33
+	assert.Contains(t, weatherControl, `"factor_min":0.7`) // 1.0 - 0.3 = 0.7
+	assert.Contains(t, weatherControl, `"factor_max":1.3`) // 1.0 + 0.3 = 1.3
+
+	// Verify NULL weather_control remains NULL
+	var nullControl sql.NullString
+	err = db.QueryRow("SELECT weather_control FROM water_schedules WHERE id = 'ws_no_weather'").Scan(&nullControl)
+	require.NoError(t, err)
+	assert.False(t, nullControl.Valid)
+
+	// Test down migration - step back just one migration
+	err = m.Steps(-1)
+	require.NoError(t, err)
+
+	// Verify rain-only reversion
+	err = db.QueryRow("SELECT weather_control FROM water_schedules WHERE id = 'ws_rain_only'").Scan(&weatherControl)
+	require.NoError(t, err)
+	assert.Contains(t, weatherControl, `"baseline_value":0`)
+	assert.Contains(t, weatherControl, `"range":25.4`)
+	assert.Contains(t, weatherControl, `"factor":0`) // 1.0 - 1.0 = 0
+	assert.Contains(t, weatherControl, `"client_id":"client1"`)
+
+	// Verify temperature-only reversion
+	err = db.QueryRow("SELECT weather_control FROM water_schedules WHERE id = 'ws_temp_only'").Scan(&weatherControl)
+	require.NoError(t, err)
+	assert.Contains(t, weatherControl, `"baseline_value":30`) // (20 + 40) / 2 = 30
+	assert.Contains(t, weatherControl, `"range":10`)          // (40 - 20) / 2 = 10
+	assert.Contains(t, weatherControl, `"factor":0.5`)        // 1.5 - 1.0 = 0.5
+	assert.Contains(t, weatherControl, `"client_id":"client2"`)
+}
+
 func TestNotificationClientStorage(t *testing.T) {
 	ctx := context.Background()
 

--- a/garden-app/pkg/storage/migrations/000005_weather_scaler.down.sql
+++ b/garden-app/pkg/storage/migrations/000005_weather_scaler.down.sql
@@ -1,5 +1,5 @@
 -- Down migration to revert weather_control from WeatherScaler format back to ScaleControl format
--- New format: {enabled, client_id, interpolation, input_min, input_max, factor_min, factor_max}
+-- New format: {client_id, interpolation, input_min, input_max, factor_min, factor_max}
 -- Old format: {baseline_value, factor, range, client_id}
 
 -- Revert rain_control: rain scales down only

--- a/garden-app/pkg/storage/migrations/000005_weather_scaler.down.sql
+++ b/garden-app/pkg/storage/migrations/000005_weather_scaler.down.sql
@@ -1,0 +1,39 @@
+-- Down migration to revert weather_control from WeatherScaler format back to ScaleControl format
+-- New format: {enabled, client_id, interpolation, input_min, input_max, factor_min, factor_max}
+-- Old format: {baseline_value, factor, range, client_id}
+
+-- Revert rain_control: rain scales down only
+-- baseline_value = input_min
+-- range = input_max - input_min
+-- factor = 1.0 - factor_min
+UPDATE water_schedules
+SET weather_control = json_set(
+    weather_control,
+    '$.rain_control',
+    json_object(
+        'client_id', json_extract(weather_control, '$.rain_control.client_id'),
+        'baseline_value', json_extract(weather_control, '$.rain_control.input_min'),
+        'range', json_extract(weather_control, '$.rain_control.input_max') - json_extract(weather_control, '$.rain_control.input_min'),
+        'factor', 1.0 - json_extract(weather_control, '$.rain_control.factor_min')
+    )
+)
+WHERE json_extract(weather_control, '$.rain_control') IS NOT NULL
+  AND json_extract(weather_control, '$.rain_control.input_min') IS NOT NULL;
+
+-- Revert temperature_control: temperature scales up and down
+-- baseline_value = (input_min + input_max) / 2
+-- range = (input_max - input_min) / 2
+-- factor = factor_max - 1.0
+UPDATE water_schedules
+SET weather_control = json_set(
+    weather_control,
+    '$.temperature_control',
+    json_object(
+        'client_id', json_extract(weather_control, '$.temperature_control.client_id'),
+        'baseline_value', (json_extract(weather_control, '$.temperature_control.input_min') + json_extract(weather_control, '$.temperature_control.input_max')) / 2.0,
+        'range', (json_extract(weather_control, '$.temperature_control.input_max') - json_extract(weather_control, '$.temperature_control.input_min')) / 2.0,
+        'factor', json_extract(weather_control, '$.temperature_control.factor_max') - 1.0
+    )
+)
+WHERE json_extract(weather_control, '$.temperature_control') IS NOT NULL
+  AND json_extract(weather_control, '$.temperature_control.input_min') IS NOT NULL;

--- a/garden-app/pkg/storage/migrations/000005_weather_scaler.up.sql
+++ b/garden-app/pkg/storage/migrations/000005_weather_scaler.up.sql
@@ -1,6 +1,6 @@
 -- Migration to convert weather_control from ScaleControl format to WeatherScaler format
 -- Old format: {baseline_value, factor, range, client_id}
--- New format: {enabled, client_id, interpolation, input_min, input_max, factor_min, factor_max}
+-- New format: {client_id, interpolation, input_min, input_max, factor_min, factor_max}
 
 -- Update rain_control: rain scales down only
 -- input_min = baseline_value
@@ -12,7 +12,6 @@ SET weather_control = json_set(
     weather_control,
     '$.rain_control',
     json_object(
-        'enabled', true,
         'client_id', json_extract(weather_control, '$.rain_control.client_id'),
         'interpolation', 'linear',
         'input_min', json_extract(weather_control, '$.rain_control.baseline_value'),
@@ -34,7 +33,6 @@ SET weather_control = json_set(
     weather_control,
     '$.temperature_control',
     json_object(
-        'enabled', true,
         'client_id', json_extract(weather_control, '$.temperature_control.client_id'),
         'interpolation', 'linear',
         'input_min', json_extract(weather_control, '$.temperature_control.baseline_value') - json_extract(weather_control, '$.temperature_control.range'),

--- a/garden-app/pkg/storage/migrations/000005_weather_scaler.up.sql
+++ b/garden-app/pkg/storage/migrations/000005_weather_scaler.up.sql
@@ -1,0 +1,47 @@
+-- Migration to convert weather_control from ScaleControl format to WeatherScaler format
+-- Old format: {baseline_value, factor, range, client_id}
+-- New format: {enabled, client_id, interpolation, input_min, input_max, factor_min, factor_max}
+
+-- Update rain_control: rain scales down only
+-- input_min = baseline_value
+-- input_max = baseline_value + range
+-- factor_min = 1.0 - factor
+-- factor_max = 1.0
+UPDATE water_schedules
+SET weather_control = json_set(
+    weather_control,
+    '$.rain_control',
+    json_object(
+        'enabled', true,
+        'client_id', json_extract(weather_control, '$.rain_control.client_id'),
+        'interpolation', 'linear',
+        'input_min', json_extract(weather_control, '$.rain_control.baseline_value'),
+        'input_max', json_extract(weather_control, '$.rain_control.baseline_value') + json_extract(weather_control, '$.rain_control.range'),
+        'factor_min', 1.0 - json_extract(weather_control, '$.rain_control.factor'),
+        'factor_max', 1.0
+    )
+)
+WHERE json_extract(weather_control, '$.rain_control') IS NOT NULL
+  AND json_extract(weather_control, '$.rain_control.baseline_value') IS NOT NULL;
+
+-- Update temperature_control: temperature scales up and down
+-- input_min = baseline_value - range
+-- input_max = baseline_value + range
+-- factor_min = 1.0 - factor
+-- factor_max = 1.0 + factor
+UPDATE water_schedules
+SET weather_control = json_set(
+    weather_control,
+    '$.temperature_control',
+    json_object(
+        'enabled', true,
+        'client_id', json_extract(weather_control, '$.temperature_control.client_id'),
+        'interpolation', 'linear',
+        'input_min', json_extract(weather_control, '$.temperature_control.baseline_value') - json_extract(weather_control, '$.temperature_control.range'),
+        'input_max', json_extract(weather_control, '$.temperature_control.baseline_value') + json_extract(weather_control, '$.temperature_control.range'),
+        'factor_min', 1.0 - json_extract(weather_control, '$.temperature_control.factor'),
+        'factor_max', 1.0 + json_extract(weather_control, '$.temperature_control.factor')
+    )
+)
+WHERE json_extract(weather_control, '$.temperature_control') IS NOT NULL
+  AND json_extract(weather_control, '$.temperature_control.baseline_value') IS NOT NULL;

--- a/garden-app/pkg/water_schedule.go
+++ b/garden-app/pkg/water_schedule.go
@@ -290,40 +290,16 @@ func (ws *WaterSchedule) Bind(r *http.Request) error {
 // ValidateWeatherControl validates input for the WeatherControl of a WaterSchedule
 func ValidateWeatherControl(wc *weather.Control) error {
 	if wc.Temperature != nil {
-		err := ValidateScaleControl(wc.Temperature)
+		err := wc.Temperature.Validate()
 		if err != nil {
 			return fmt.Errorf("error validating temperature_control: %w", err)
 		}
 	}
 	if wc.Rain != nil {
-		err := ValidateScaleControl(wc.Rain)
+		err := wc.Rain.Validate()
 		if err != nil {
 			return fmt.Errorf("error validating rain_control: %w", err)
 		}
-	}
-	return nil
-}
-
-// ValidateScaleControl validates input for ScaleControl
-func ValidateScaleControl(sc *weather.ScaleControl) error {
-	errStringFormat := "missing required field: %s"
-	if sc.BaselineValue == nil {
-		return fmt.Errorf(errStringFormat, "baseline_value")
-	}
-	if sc.Factor == nil {
-		return fmt.Errorf(errStringFormat, "factor")
-	}
-	if *sc.Factor > float32(1) || *sc.Factor < float32(0) {
-		return errors.New("factor must be between 0 and 1")
-	}
-	if sc.Range == nil {
-		return fmt.Errorf(errStringFormat, "range")
-	}
-	if *sc.Range < float32(0) {
-		return errors.New("range must be a positive number")
-	}
-	if sc.ClientID.IsNil() {
-		return fmt.Errorf(errStringFormat, "client_id")
 	}
 	return nil
 }

--- a/garden-app/pkg/water_schedule_test.go
+++ b/garden-app/pkg/water_schedule_test.go
@@ -7,9 +7,14 @@ import (
 
 	"github.com/calvinmclean/automated-garden/garden-app/clock"
 	"github.com/calvinmclean/automated-garden/garden-app/pkg/weather"
+	"github.com/rs/xid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func float64Ptr(f float64) *float64 {
+	return &f
+}
 
 func TestWaterScheduleEndDated(t *testing.T) {
 	pastDate := clock.Now().Add(-1 * time.Minute)
@@ -35,7 +40,6 @@ func TestWaterScheduleEndDated(t *testing.T) {
 }
 
 func TestWaterSchedulePatch(t *testing.T) {
-	float := float32(1)
 	now := clock.Now()
 	tests := []struct {
 		name             string
@@ -78,13 +82,15 @@ func TestWaterSchedulePatch(t *testing.T) {
 			},
 		},
 		{
-			"PatchWeatherControl.Temperature",
+			"PatchWeatherControl.Rain",
 			&WaterSchedule{
 				WeatherControl: &weather.Control{
-					Rain: &weather.ScaleControl{
-						BaselineValue: &float,
-						Factor:        &float,
-						Range:         &float,
+					Rain: &weather.WeatherScaler{
+						ClientID:  xid.New(),
+						InputMin:  float64Ptr(0.0),
+						InputMax:  float64Ptr(25.4),
+						FactorMin: float64Ptr(0.5),
+						FactorMax: float64Ptr(1.0),
 					},
 				},
 			},
@@ -93,10 +99,12 @@ func TestWaterSchedulePatch(t *testing.T) {
 			"PatchWeatherControl.Temperature",
 			&WaterSchedule{
 				WeatherControl: &weather.Control{
-					Temperature: &weather.ScaleControl{
-						BaselineValue: &float,
-						Factor:        &float,
-						Range:         &float,
+					Temperature: &weather.WeatherScaler{
+						ClientID:  xid.New(),
+						InputMin:  float64Ptr(20.0),
+						InputMax:  float64Ptr(40.0),
+						FactorMin: float64Ptr(0.5),
+						FactorMax: float64Ptr(1.5),
 					},
 				},
 			},

--- a/garden-app/pkg/weather/control.go
+++ b/garden-app/pkg/weather/control.go
@@ -5,21 +5,21 @@ import "github.com/rs/xid"
 
 // Control defines certain parameters and behaviors to influence watering patterns based off weather data
 type Control struct {
-	Rain        *ScaleControl `json:"rain_control,omitempty"`
-	Temperature *ScaleControl `json:"temperature_control,omitempty"`
+	Rain        *WeatherScaler `json:"rain_control,omitempty"`
+	Temperature *WeatherScaler `json:"temperature_control,omitempty"`
 }
 
 // Patch allows modifying the struct in-place with values from a different instance
 func (wc *Control) Patch(newControl *Control) {
 	if newControl.Rain != nil {
 		if wc.Rain == nil {
-			wc.Rain = &ScaleControl{}
+			wc.Rain = &WeatherScaler{}
 		}
 		wc.Rain.Patch(newControl.Rain)
 	}
 	if newControl.Temperature != nil {
 		if wc.Temperature == nil {
-			wc.Temperature = &ScaleControl{}
+			wc.Temperature = &WeatherScaler{}
 		}
 		wc.Temperature.Patch(newControl.Temperature)
 	}

--- a/garden-app/pkg/weather/control.go
+++ b/garden-app/pkg/weather/control.go
@@ -1,8 +1,6 @@
 // Package weather provides weather client interfaces and implementations
 package weather
 
-import "github.com/rs/xid"
-
 // Control defines certain parameters and behaviors to influence watering patterns based off weather data
 type Control struct {
 	Rain        *WeatherScaler `json:"rain_control,omitempty"`
@@ -23,75 +21,4 @@ func (wc *Control) Patch(newControl *Control) {
 		}
 		wc.Temperature.Patch(newControl.Temperature)
 	}
-}
-
-// ScaleControl is a generic struct that enables scaling
-// BaselineValue is the value that scaling starts at
-// Range is the most extreme value that scaling will go to (used as max/min)
-// Factor is the maximum amount that this will scale by. This must be between 0 and 1, where 0 is no scaling and 1 scale by the full proportion of the range
-// When a measured value is equal to or greater than the BaselineValue, factor is used to scale up the current value based
-// on the proportion of the difference between current value and BaselineValue to the Range
-//
-// For example:
-// BaselineValue: 90, Factor: 0.5, Range: 30, WaterDuration: 30m
-//   - Input 100 degrees: (100 - 90)/30 * 0.5 + 1 = 1.1666666667 => water 35m
-//   - Input 120 degrees: (120 - 90)/30 * 0.5 + 1 = 1.5, max scaling
-//   - Input 130 degrees: (130 - 90)/30 * 0.5 + 1 = 1.6666666667 => greater than factor of 0.5, so we cut off at 1.5 and water 45m
-//   - Input  80 degrees: ( 80 - 90)/30 * 0.5 + 1 = 0.8333333333 => water 25m
-//   - Input  60 degrees: ( 60 - 90)/30 * 0.5 + 1 = 0.5 => water 15m
-//   - Input  50 degrees: ( 50 - 90)/30 * 0.5 + 1 = 0.3333333333 => less than factor of 0.5, so we round up to 0.5
-//
-// Basically, a Factor of 0.5 means that if watering is set at 30m, I want to water at most 45 min and at least 15 min
-// This way, the control doesn't need to know anything about the durations and can just return a multiplier that
-// makes this happen
-type ScaleControl struct {
-	BaselineValue *float32 `json:"baseline_value"`
-	Factor        *float32 `json:"factor"`
-	Range         *float32 `json:"range"`
-	ClientID      xid.ID   `json:"client_id"`
-}
-
-// Patch allows modifying the struct in-place with values from a different instance
-func (sc *ScaleControl) Patch(newScaleControl *ScaleControl) {
-	if newScaleControl.BaselineValue != nil {
-		sc.BaselineValue = newScaleControl.BaselineValue
-	}
-	if newScaleControl.Factor != nil {
-		sc.Factor = newScaleControl.Factor
-	}
-	if newScaleControl.Range != nil {
-		sc.Range = newScaleControl.Range
-	}
-	if !newScaleControl.ClientID.IsNil() {
-		sc.ClientID = newScaleControl.ClientID
-	}
-}
-
-// Scale calculates and returns the multiplier based on the input value
-func (sc *ScaleControl) Scale(actualValue float32) float32 {
-	diff := actualValue - *sc.BaselineValue
-	r := *sc.Range
-	if diff > r {
-		diff = r
-	}
-	if diff < -r {
-		diff = -r
-	}
-	return (diff/r)*(*sc.Factor) + 1
-}
-
-// InvertedScaleDownOnly calculates and returns the multiplier based on the input value, but is inverted
-// so higher input values cause scaling < 1. Also it will only scale in this direction
-func (sc *ScaleControl) InvertedScaleDownOnly(actualValue float32) float32 {
-	// If the baseline is not reached, just scale 1
-	if actualValue < *sc.BaselineValue {
-		return 1
-	}
-
-	diff := actualValue - *sc.BaselineValue
-	r := *sc.Range
-	if diff > r {
-		diff = r
-	}
-	return 1 - (diff/r)*(1-*sc.Factor)
 }

--- a/garden-app/pkg/weather/control_test.go
+++ b/garden-app/pkg/weather/control_test.go
@@ -2,54 +2,65 @@ package weather
 
 import (
 	"testing"
-	"time"
 
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPatch(t *testing.T) {
+func float64Ptr(f float64) *float64 {
+	return &f
+}
+
+func TestControlPatch(t *testing.T) {
 	tests := []struct {
 		name       string
 		newControl *Control
 	}{
 		{
-			"PatchRain.BaselineValue",
+			"PatchRain.InputMin",
 			&Control{
-				Rain: &ScaleControl{
-					BaselineValue: float32Pointer(25.4),
+				Rain: &WeatherScaler{
+					InputMin: float64Ptr(0.0),
 				},
 			},
 		},
 		{
-			"PatchRain.Factor",
+			"PatchRain.InputMax",
 			&Control{
-				Rain: &ScaleControl{
-					Factor: float32Pointer(25.4),
+				Rain: &WeatherScaler{
+					InputMax: float64Ptr(25.4),
 				},
 			},
 		},
 		{
-			"PatchRain.Range",
+			"PatchRain.FactorMin",
 			&Control{
-				Rain: &ScaleControl{
-					Range: float32Pointer(25.4),
+				Rain: &WeatherScaler{
+					FactorMin: float64Ptr(0.5),
 				},
 			},
 		},
 		{
-			"PatchRain.ID",
+			"PatchRain.FactorMax",
 			&Control{
-				Rain: &ScaleControl{
+				Rain: &WeatherScaler{
+					FactorMax: float64Ptr(1.0),
+				},
+			},
+		},
+		{
+			"PatchRain.ClientID",
+			&Control{
+				Rain: &WeatherScaler{
 					ClientID: xid.New(),
 				},
 			},
 		},
 		{
-			"PatchTemperature.BaselineValue",
+			"PatchTemperature.InputMin",
 			&Control{
-				Temperature: &ScaleControl{
-					BaselineValue: float32Pointer(25.4),
+				Temperature: &WeatherScaler{
+					InputMin: float64Ptr(20.0),
 				},
 			},
 		},
@@ -63,181 +74,17 @@ func TestPatch(t *testing.T) {
 		})
 		t.Run(tt.name+"WithAllExisting", func(t *testing.T) {
 			if tt.newControl.Rain == nil {
-				tt.newControl.Rain = &ScaleControl{}
+				tt.newControl.Rain = &WeatherScaler{}
 			}
 			if tt.newControl.Temperature == nil {
-				tt.newControl.Temperature = &ScaleControl{}
+				tt.newControl.Temperature = &WeatherScaler{}
 			}
 			c := &Control{
-				Rain:        &ScaleControl{},
-				Temperature: &ScaleControl{},
+				Rain:        &WeatherScaler{},
+				Temperature: &WeatherScaler{},
 			}
 			c.Patch(tt.newControl)
 			assert.Equal(t, tt.newControl, c)
 		})
 	}
-}
-
-func TestScale(t *testing.T) {
-	baseline := float32(90)
-	factor := float32(0.5)
-	r := float32(30)
-	sc := ScaleControl{
-		BaselineValue: &baseline,
-		Factor:        &factor,
-		Range:         &r,
-	}
-
-	tests := []struct {
-		name             string
-		input            float32
-		expectedFactor   float32
-		expectedDuration time.Duration
-	}{
-		{
-			"ScaleUpABit",
-			100,
-			1 + 1.0/6,
-			35 * time.Minute,
-		},
-		{
-			"MaxScaleUp",
-			120,
-			1.5,
-			45 * time.Minute,
-		},
-		{
-			"BeyondMaxScaleUp",
-			130,
-			1.5,
-			45 * time.Minute,
-		},
-		{
-			"ScaleDownABit",
-			80,
-			1 - 1.0/6,
-			25 * time.Minute,
-		},
-		{
-			"MaxScaleDown",
-			60,
-			0.5,
-			15 * time.Minute,
-		},
-		{
-			"BeyondMaxScaleDown",
-			50,
-			0.5,
-			15 * time.Minute,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			scale := sc.Scale(tt.input)
-			assert.Equal(t, tt.expectedFactor, scale)
-			baseDuration := time.Minute * 30
-			scaledDuration := time.Duration(int64(float32(baseDuration) * scale)).Round(time.Second)
-			assert.Equal(t, tt.expectedDuration, scaledDuration)
-		})
-	}
-}
-
-func TestInvertedScaleDownOnly(t *testing.T) {
-	sc := ScaleControl{
-		BaselineValue: float32Pointer(25.4),
-		Factor:        float32Pointer(0.5),
-		Range:         float32Pointer(12.7),
-	}
-
-	// Any amount of rain will scale watering down, 2 inches will stop all watering
-	fullRangeScale := ScaleControl{
-		BaselineValue: float32Pointer(0),
-		Factor:        float32Pointer(0),
-		Range:         float32Pointer(50),
-	}
-
-	tests := []struct {
-		name             string
-		sc               ScaleControl
-		input            float32
-		expectedFactor   float32
-		expectedDuration time.Duration
-	}{
-		{
-			"ValueBelowThresholdNoChange",
-			sc,
-			20,
-			1,
-			30 * time.Minute,
-		},
-		{
-			"1/2RangePastBaselineScales75%",
-			sc,
-			25.4 + 6.35,
-			0.75,
-			22*time.Minute + 30*time.Second,
-		},
-		{
-			"FullRangePastBaselineScales50%",
-			sc,
-			25.4 + 12.7,
-			0.5,
-			15 * time.Minute,
-		},
-		{
-			"BeyondRangeMaxesScaleFactor",
-			sc,
-			50,
-			0.5,
-			15 * time.Minute,
-		},
-		{
-			"ScaleToZero",
-			ScaleControl{
-				BaselineValue: float32Pointer(25.4),
-				Factor:        float32Pointer(0),
-				Range:         float32Pointer(10),
-			},
-			35.4,
-			0,
-			0,
-		},
-		{
-			"FullRangeNoScale",
-			fullRangeScale,
-			0,
-			1,
-			30 * time.Minute,
-		},
-		{
-			"FullRangeHalfway",
-			fullRangeScale,
-			25,
-			0.5,
-			15 * time.Minute,
-		},
-		{
-			"FullRangeScaleToZero",
-			fullRangeScale,
-			50,
-			0,
-			0,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			scale := tt.sc.InvertedScaleDownOnly(tt.input)
-			assert.Equal(t, tt.expectedFactor, scale)
-			baseDuration := time.Minute * 30
-			scaledDuration := time.Duration(int64(float32(baseDuration) * scale)).Round(time.Second)
-			assert.Equal(t, tt.expectedDuration, scaledDuration)
-		})
-	}
-}
-
-func float32Pointer(n float64) *float32 {
-	f := float32(n)
-	return &f
 }

--- a/garden-app/pkg/weather/interpolation.go
+++ b/garden-app/pkg/weather/interpolation.go
@@ -1,0 +1,91 @@
+package weather
+
+// Interpolator defines the interface for interpolation algorithms
+type Interpolator interface {
+	Interpolate(t float64) float64 // t is normalized 0-1
+}
+
+// InterpolationMode represents the type of interpolation to use
+type InterpolationMode string
+
+const (
+	Linear    InterpolationMode = "linear"
+	EaseIn    InterpolationMode = "ease_in"
+	EaseOut   InterpolationMode = "ease_out"
+	EaseInOut InterpolationMode = "ease_in_out"
+	Step      InterpolationMode = "step"
+)
+
+// IsValid checks if the interpolation mode is valid
+func (m InterpolationMode) IsValid() bool {
+	switch m {
+	case Linear, EaseIn, EaseOut, EaseInOut, Step:
+		return true
+	}
+	return false
+}
+
+// LinearInterpolator implements linear interpolation (t -> t)
+type LinearInterpolator struct{}
+
+// Interpolate performs linear interpolation: t
+func (l LinearInterpolator) Interpolate(t float64) float64 {
+	return t
+}
+
+// EaseInInterpolator implements ease-in interpolation (t -> t²)
+type EaseInInterpolator struct{}
+
+// Interpolate performs ease-in interpolation: t²
+func (e EaseInInterpolator) Interpolate(t float64) float64 {
+	return t * t
+}
+
+// EaseOutInterpolator implements ease-out interpolation (t -> 1 - (1-t)²)
+type EaseOutInterpolator struct{}
+
+// Interpolate performs ease-out interpolation: 1 - (1-t)²
+func (e EaseOutInterpolator) Interpolate(t float64) float64 {
+	return 1 - (1-t)*(1-t)
+}
+
+// EaseInOutInterpolator implements ease-in-out interpolation
+type EaseInOutInterpolator struct{}
+
+// Interpolate performs ease-in-out interpolation:
+// t < 0.5 ? 2t² : 1 - 2(1-t)²
+func (e EaseInOutInterpolator) Interpolate(t float64) float64 {
+	if t < 0.5 {
+		return 2 * t * t
+	}
+	return 1 - 2*(1-t)*(1-t)
+}
+
+// StepInterpolator implements step interpolation
+type StepInterpolator struct{}
+
+// Interpolate performs step interpolation: t < 1 ? 0 : 1
+func (s StepInterpolator) Interpolate(t float64) float64 {
+	if t < 1.0 {
+		return 0.0
+	}
+	return 1.0
+}
+
+// GetInterpolator returns the appropriate interpolator for the given mode
+func GetInterpolator(mode InterpolationMode) Interpolator {
+	switch mode {
+	case EaseIn:
+		return EaseInInterpolator{}
+	case EaseOut:
+		return EaseOutInterpolator{}
+	case EaseInOut:
+		return EaseInOutInterpolator{}
+	case Step:
+		return StepInterpolator{}
+	case Linear:
+	default:
+		return LinearInterpolator{}
+	}
+	return LinearInterpolator{}
+}

--- a/garden-app/pkg/weather/scaler.go
+++ b/garden-app/pkg/weather/scaler.go
@@ -3,33 +3,68 @@ package weather
 import (
 	"errors"
 	"fmt"
+
+	"github.com/rs/xid"
 )
 
 // WeatherScaler defines the configuration for weather-based duration scaling
 // using min/max input-output pairs with configurable interpolation
 type WeatherScaler struct {
-	Enabled       bool              `json:"enabled" yaml:"enabled"`
-	ClientID      string            `json:"client_id" yaml:"client_id"`
+	ClientID      xid.ID            `json:"client_id" yaml:"client_id"`
 	Interpolation InterpolationMode `json:"interpolation" yaml:"interpolation"`
-	InputMin      float64           `json:"input_min" yaml:"input_min"`
-	InputMax      float64           `json:"input_max" yaml:"input_max"`
-	FactorMin     float64           `json:"factor_min" yaml:"factor_min"`
-	FactorMax     float64           `json:"factor_max" yaml:"factor_max"`
+	InputMin      *float64          `json:"input_min" yaml:"input_min"`
+	InputMax      *float64          `json:"input_max" yaml:"input_max"`
+	FactorMin     *float64          `json:"factor_min" yaml:"factor_min"`
+	FactorMax     *float64          `json:"factor_max" yaml:"factor_max"`
+}
+
+// Patch allows modifying the struct in-place with values from a different instance
+func (ws *WeatherScaler) Patch(newScaler *WeatherScaler) {
+	if !newScaler.ClientID.IsNil() {
+		ws.ClientID = newScaler.ClientID
+	}
+	if newScaler.Interpolation != "" {
+		ws.Interpolation = newScaler.Interpolation
+	}
+	if newScaler.InputMin != nil {
+		ws.InputMin = newScaler.InputMin
+	}
+	if newScaler.InputMax != nil {
+		ws.InputMax = newScaler.InputMax
+	}
+	if newScaler.FactorMin != nil {
+		ws.FactorMin = newScaler.FactorMin
+	}
+	if newScaler.FactorMax != nil {
+		ws.FactorMax = newScaler.FactorMax
+	}
 }
 
 // Validate checks that the WeatherScaler configuration is valid
 func (ws *WeatherScaler) Validate() error {
-	if !ws.Enabled {
-		return nil
+	if ws.InputMin == nil {
+		return errors.New("missing required field: input_min")
 	}
-	if ws.InputMax <= ws.InputMin {
+	if ws.InputMax == nil {
+		return errors.New("missing required field: input_max")
+	}
+	if *ws.InputMax <= *ws.InputMin {
 		return errors.New("input_max must be greater than input_min")
 	}
-	if ws.FactorMin < 0 || ws.FactorMax < 0 {
+	if ws.FactorMin == nil {
+		return errors.New("missing required field: factor_min")
+	}
+	if ws.FactorMax == nil {
+		return errors.New("missing required field: factor_max")
+	}
+	if *ws.FactorMin < 0 || *ws.FactorMax < 0 {
 		return errors.New("factors must be non-negative")
 	}
 	if !ws.Interpolation.IsValid() {
 		return fmt.Errorf("invalid interpolation mode: %s", ws.Interpolation)
+	}
+	if ws.ClientID.IsNil() {
+		return errors.New("missing required field: client_id")
 	}
 	return nil
 }
@@ -38,33 +73,33 @@ func (ws *WeatherScaler) Validate() error {
 // It applies clamping for values outside the input range and
 // interpolates values within the range.
 func (ws *WeatherScaler) Scale(input float64) float64 {
-	if !ws.Enabled {
+	// Handle nil pointers gracefully (should not happen after validation)
+	if ws.InputMin == nil || ws.InputMax == nil || ws.FactorMin == nil || ws.FactorMax == nil {
 		return 1.0
 	}
 
 	// Clamp to lower boundary
-	if input <= ws.InputMin {
-		return ws.FactorMin
+	if input <= *ws.InputMin {
+		return *ws.FactorMin
 	}
 
 	// Clamp to upper boundary
-	if input >= ws.InputMax {
-		return ws.FactorMax
+	if input >= *ws.InputMax {
+		return *ws.FactorMax
 	}
 
 	// Normalize input to 0-1 range
-	t := (input - ws.InputMin) / (ws.InputMax - ws.InputMin)
+	t := (input - *ws.InputMin) / (*ws.InputMax - *ws.InputMin)
 
 	// Apply interpolation
 	interpolator := GetInterpolator(ws.Interpolation)
 	interpolated := interpolator.Interpolate(t)
 
 	// Map interpolated value to output range
-	return ws.FactorMin + (ws.FactorMax-ws.FactorMin)*interpolated
+	return *ws.FactorMin + (*ws.FactorMax-*ws.FactorMin)*interpolated
 }
 
 // ScaleMulti multiplies multiple scaler factors together.
-// Disabled scalers contribute a factor of 1.0.
 func ScaleMulti(scalers []*WeatherScaler, inputs []float64) float64 {
 	if len(scalers) != len(inputs) {
 		return 1.0

--- a/garden-app/pkg/weather/scaler.go
+++ b/garden-app/pkg/weather/scaler.go
@@ -1,0 +1,78 @@
+package weather
+
+import (
+	"errors"
+	"fmt"
+)
+
+// WeatherScaler defines the configuration for weather-based duration scaling
+// using min/max input-output pairs with configurable interpolation
+type WeatherScaler struct {
+	Enabled       bool              `json:"enabled" yaml:"enabled"`
+	ClientID      string            `json:"client_id" yaml:"client_id"`
+	Interpolation InterpolationMode `json:"interpolation" yaml:"interpolation"`
+	InputMin      float64           `json:"input_min" yaml:"input_min"`
+	InputMax      float64           `json:"input_max" yaml:"input_max"`
+	FactorMin     float64           `json:"factor_min" yaml:"factor_min"`
+	FactorMax     float64           `json:"factor_max" yaml:"factor_max"`
+}
+
+// Validate checks that the WeatherScaler configuration is valid
+func (ws *WeatherScaler) Validate() error {
+	if !ws.Enabled {
+		return nil
+	}
+	if ws.InputMax <= ws.InputMin {
+		return errors.New("input_max must be greater than input_min")
+	}
+	if ws.FactorMin < 0 || ws.FactorMax < 0 {
+		return errors.New("factors must be non-negative")
+	}
+	if !ws.Interpolation.IsValid() {
+		return fmt.Errorf("invalid interpolation mode: %s", ws.Interpolation)
+	}
+	return nil
+}
+
+// Scale calculates the scale factor for the given input value.
+// It applies clamping for values outside the input range and
+// interpolates values within the range.
+func (ws *WeatherScaler) Scale(input float64) float64 {
+	if !ws.Enabled {
+		return 1.0
+	}
+
+	// Clamp to lower boundary
+	if input <= ws.InputMin {
+		return ws.FactorMin
+	}
+
+	// Clamp to upper boundary
+	if input >= ws.InputMax {
+		return ws.FactorMax
+	}
+
+	// Normalize input to 0-1 range
+	t := (input - ws.InputMin) / (ws.InputMax - ws.InputMin)
+
+	// Apply interpolation
+	interpolator := GetInterpolator(ws.Interpolation)
+	interpolated := interpolator.Interpolate(t)
+
+	// Map interpolated value to output range
+	return ws.FactorMin + (ws.FactorMax-ws.FactorMin)*interpolated
+}
+
+// ScaleMulti multiplies multiple scaler factors together.
+// Disabled scalers contribute a factor of 1.0.
+func ScaleMulti(scalers []*WeatherScaler, inputs []float64) float64 {
+	if len(scalers) != len(inputs) {
+		return 1.0
+	}
+
+	result := 1.0
+	for i, scaler := range scalers {
+		result *= scaler.Scale(inputs[i])
+	}
+	return result
+}

--- a/garden-app/pkg/weather/scaler_test.go
+++ b/garden-app/pkg/weather/scaler_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/rs/xid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -122,12 +123,11 @@ func TestInterpolationModeIsValid(t *testing.T) {
 // Test WeatherScaler Scale method with clamping
 func TestWeatherScalerClamping(t *testing.T) {
 	scaler := &WeatherScaler{
-		Enabled:       true,
 		Interpolation: Linear,
-		InputMin:      10.0,
-		InputMax:      50.0,
-		FactorMin:     0.5,
-		FactorMax:     1.5,
+		InputMin:      float64Ptr(10.0),
+		InputMax:      float64Ptr(50.0),
+		FactorMin:     float64Ptr(0.5),
+		FactorMax:     float64Ptr(1.5),
 	}
 
 	tests := []struct {
@@ -150,32 +150,14 @@ func TestWeatherScalerClamping(t *testing.T) {
 	}
 }
 
-// Test disabled WeatherScaler returns 1.0
-func TestWeatherScalerDisabled(t *testing.T) {
-	scaler := &WeatherScaler{
-		Enabled:       false,
-		Interpolation: Linear,
-		InputMin:      10.0,
-		InputMax:      50.0,
-		FactorMin:     0.5,
-		FactorMax:     1.5,
-	}
-
-	// Should return 1.0 regardless of input when disabled
-	assert.InDelta(t, 1.0, scaler.Scale(5.0), 0.0001)
-	assert.InDelta(t, 1.0, scaler.Scale(30.0), 0.0001)
-	assert.InDelta(t, 1.0, scaler.Scale(60.0), 0.0001)
-}
-
 // Scenario 1: Rain Scaler - Input: 0-30mm, Output: 1.0-0.0 (linear)
 func TestRainScenario(t *testing.T) {
 	rainScaler := &WeatherScaler{
-		Enabled:       true,
 		Interpolation: Linear,
-		InputMin:      0.0,
-		InputMax:      30.0,
-		FactorMin:     1.0,
-		FactorMax:     0.0,
+		InputMin:      float64Ptr(0.0),
+		InputMax:      float64Ptr(30.0),
+		FactorMin:     float64Ptr(1.0),
+		FactorMax:     float64Ptr(0.0),
 	}
 
 	tests := []struct {
@@ -198,12 +180,11 @@ func TestRainScenario(t *testing.T) {
 // Scenario 2: Temperature Scaler - Input: 20-46°C, Output: 1.0-1.5 (ease_in)
 func TestTemperatureScenario(t *testing.T) {
 	tempScaler := &WeatherScaler{
-		Enabled:       true,
 		Interpolation: EaseIn,
-		InputMin:      20.0,
-		InputMax:      46.0,
-		FactorMin:     1.0,
-		FactorMax:     1.5,
+		InputMin:      float64Ptr(20.0),
+		InputMax:      float64Ptr(46.0),
+		FactorMin:     float64Ptr(1.0),
+		FactorMax:     float64Ptr(1.5),
 	}
 
 	// Manual calculation verification
@@ -224,21 +205,19 @@ func TestTemperatureScenario(t *testing.T) {
 // Test multi-scaler multiplication
 func TestScaleMulti(t *testing.T) {
 	rainScaler := &WeatherScaler{
-		Enabled:       true,
 		Interpolation: Linear,
-		InputMin:      0.0,
-		InputMax:      30.0,
-		FactorMin:     1.0,
-		FactorMax:     0.0,
+		InputMin:      float64Ptr(0.0),
+		InputMax:      float64Ptr(30.0),
+		FactorMin:     float64Ptr(1.0),
+		FactorMax:     float64Ptr(0.0),
 	}
 
 	tempScaler := &WeatherScaler{
-		Enabled:       true,
 		Interpolation: Linear,
-		InputMin:      20.0,
-		InputMax:      46.0,
-		FactorMin:     1.0,
-		FactorMax:     1.5,
+		InputMin:      float64Ptr(20.0),
+		InputMax:      float64Ptr(46.0),
+		FactorMin:     float64Ptr(1.0),
+		FactorMax:     float64Ptr(1.5),
 	}
 
 	// rain: 6mm -> t=0.2 -> 0.8, temp: 30C -> t=(30-20)/26=10/26 -> 1.0+0.5*(10/26)=1.1923...
@@ -250,43 +229,14 @@ func TestScaleMulti(t *testing.T) {
 	assert.InDelta(t, 0.953846, result, 0.0001)
 }
 
-// Test multi-scaler with disabled scaler
-func TestScaleMultiWithDisabled(t *testing.T) {
-	enabledScaler := &WeatherScaler{
-		Enabled:       true,
-		Interpolation: Linear,
-		InputMin:      0.0,
-		InputMax:      10.0,
-		FactorMin:     0.5,
-		FactorMax:     1.0,
-	}
-
-	disabledScaler := &WeatherScaler{
-		Enabled:       false,
-		Interpolation: Linear,
-		InputMin:      0.0,
-		InputMax:      10.0,
-		FactorMin:     0.5,
-		FactorMax:     1.0,
-	}
-
-	// enabled: 0.5 (at InputMin), disabled: 1.0 → expected: 0.5
-	scalers := []*WeatherScaler{enabledScaler, disabledScaler}
-	inputs := []float64{0.0, 5.0}
-
-	result := ScaleMulti(scalers, inputs)
-	assert.InDelta(t, 0.5, result, 0.0001)
-}
-
 // Test ScaleMulti with mismatched lengths
 func TestScaleMultiMismatchedLengths(t *testing.T) {
 	scaler := &WeatherScaler{
-		Enabled:       true,
 		Interpolation: Linear,
-		InputMin:      0.0,
-		InputMax:      10.0,
-		FactorMin:     0.5,
-		FactorMax:     1.0,
+		InputMin:      float64Ptr(0.0),
+		InputMax:      float64Ptr(10.0),
+		FactorMin:     float64Ptr(0.5),
+		FactorMax:     float64Ptr(1.0),
 	}
 
 	// Mismatched lengths should return 1.0
@@ -305,36 +255,23 @@ func TestWeatherScalerValidate(t *testing.T) {
 		{
 			name: "valid config",
 			scaler: WeatherScaler{
-				Enabled:       true,
+				ClientID:      xid.New(),
 				Interpolation: Linear,
-				InputMin:      0.0,
-				InputMax:      10.0,
-				FactorMin:     0.5,
-				FactorMax:     1.5,
-			},
-			wantError: false,
-		},
-		{
-			name: "disabled scaler skips validation",
-			scaler: WeatherScaler{
-				Enabled:       false,
-				Interpolation: "invalid",
-				InputMin:      10.0,
-				InputMax:      0.0,  // invalid but ignored
-				FactorMin:     -1.0, // invalid but ignored
-				FactorMax:     1.0,
+				InputMin:      float64Ptr(0.0),
+				InputMax:      float64Ptr(10.0),
+				FactorMin:     float64Ptr(0.5),
+				FactorMax:     float64Ptr(1.5),
 			},
 			wantError: false,
 		},
 		{
 			name: "input_max <= input_min",
 			scaler: WeatherScaler{
-				Enabled:       true,
 				Interpolation: Linear,
-				InputMin:      10.0,
-				InputMax:      10.0,
-				FactorMin:     0.5,
-				FactorMax:     1.5,
+				InputMin:      float64Ptr(10.0),
+				InputMax:      float64Ptr(10.0),
+				FactorMin:     float64Ptr(0.5),
+				FactorMax:     float64Ptr(1.5),
 			},
 			wantError: true,
 			errMsg:    "input_max must be greater than input_min",
@@ -342,12 +279,11 @@ func TestWeatherScalerValidate(t *testing.T) {
 		{
 			name: "negative FactorMin",
 			scaler: WeatherScaler{
-				Enabled:       true,
 				Interpolation: Linear,
-				InputMin:      0.0,
-				InputMax:      10.0,
-				FactorMin:     -0.5,
-				FactorMax:     1.5,
+				InputMin:      float64Ptr(0.0),
+				InputMax:      float64Ptr(10.0),
+				FactorMin:     float64Ptr(-0.5),
+				FactorMax:     float64Ptr(1.5),
 			},
 			wantError: true,
 			errMsg:    "factors must be non-negative",
@@ -355,12 +291,11 @@ func TestWeatherScalerValidate(t *testing.T) {
 		{
 			name: "negative FactorMax",
 			scaler: WeatherScaler{
-				Enabled:       true,
 				Interpolation: Linear,
-				InputMin:      0.0,
-				InputMax:      10.0,
-				FactorMin:     0.5,
-				FactorMax:     -1.5,
+				InputMin:      float64Ptr(0.0),
+				InputMax:      float64Ptr(10.0),
+				FactorMin:     float64Ptr(0.5),
+				FactorMax:     float64Ptr(-1.5),
 			},
 			wantError: true,
 			errMsg:    "factors must be non-negative",
@@ -368,12 +303,11 @@ func TestWeatherScalerValidate(t *testing.T) {
 		{
 			name: "invalid interpolation mode",
 			scaler: WeatherScaler{
-				Enabled:       true,
 				Interpolation: "invalid_mode",
-				InputMin:      0.0,
-				InputMax:      10.0,
-				FactorMin:     0.5,
-				FactorMax:     1.5,
+				InputMin:      float64Ptr(0.0),
+				InputMax:      float64Ptr(10.0),
+				FactorMin:     float64Ptr(0.5),
+				FactorMax:     float64Ptr(1.5),
 			},
 			wantError: true,
 			errMsg:    "invalid interpolation mode",
@@ -397,12 +331,11 @@ func TestWeatherScalerValidate(t *testing.T) {
 func TestWeatherScalerEdgeCases(t *testing.T) {
 	t.Run("flat line - FactorMin equals FactorMax", func(t *testing.T) {
 		scaler := &WeatherScaler{
-			Enabled:       true,
 			Interpolation: Linear,
-			InputMin:      0.0,
-			InputMax:      10.0,
-			FactorMin:     0.5,
-			FactorMax:     0.5,
+			InputMin:      float64Ptr(0.0),
+			InputMax:      float64Ptr(10.0),
+			FactorMin:     float64Ptr(0.5),
+			FactorMax:     float64Ptr(0.5),
 		}
 
 		// Should always return 0.5 regardless of input
@@ -413,12 +346,11 @@ func TestWeatherScalerEdgeCases(t *testing.T) {
 
 	t.Run("very large input range", func(t *testing.T) {
 		scaler := &WeatherScaler{
-			Enabled:       true,
 			Interpolation: Linear,
-			InputMin:      0.0,
-			InputMax:      1e9,
-			FactorMin:     0.0,
-			FactorMax:     1.0,
+			InputMin:      float64Ptr(0.0),
+			InputMax:      float64Ptr(1e9),
+			FactorMin:     float64Ptr(0.0),
+			FactorMax:     float64Ptr(1.0),
 		}
 
 		assert.InDelta(t, 0.5, scaler.Scale(5e8), 0.0001)
@@ -426,12 +358,11 @@ func TestWeatherScalerEdgeCases(t *testing.T) {
 
 	t.Run("very small input range", func(t *testing.T) {
 		scaler := &WeatherScaler{
-			Enabled:       true,
 			Interpolation: Linear,
-			InputMin:      0.0,
-			InputMax:      0.001,
-			FactorMin:     0.0,
-			FactorMax:     1.0,
+			InputMin:      float64Ptr(0.0),
+			InputMax:      float64Ptr(0.001),
+			FactorMin:     float64Ptr(0.0),
+			FactorMax:     float64Ptr(1.0),
 		}
 
 		assert.InDelta(t, 0.5, scaler.Scale(0.0005), 0.0001)
@@ -441,12 +372,11 @@ func TestWeatherScalerEdgeCases(t *testing.T) {
 // Test floating point precision
 func TestFloatingPointPrecision(t *testing.T) {
 	scaler := &WeatherScaler{
-		Enabled:       true,
 		Interpolation: Linear,
-		InputMin:      0.0,
-		InputMax:      1.0,
-		FactorMin:     0.0,
-		FactorMax:     1.0,
+		InputMin:      float64Ptr(0.0),
+		InputMax:      float64Ptr(1.0),
+		FactorMin:     float64Ptr(0.0),
+		FactorMax:     float64Ptr(1.0),
 	}
 
 	// Test that results are precise
@@ -466,12 +396,11 @@ func TestAllInterpolationModes(t *testing.T) {
 	for _, mode := range modes {
 		t.Run(string(mode), func(t *testing.T) {
 			scaler := &WeatherScaler{
-				Enabled:       true,
 				Interpolation: mode,
-				InputMin:      0.0,
-				InputMax:      10.0,
-				FactorMin:     0.0,
-				FactorMax:     1.0,
+				InputMin:      float64Ptr(0.0),
+				InputMax:      float64Ptr(10.0),
+				FactorMin:     float64Ptr(0.0),
+				FactorMax:     float64Ptr(1.0),
 			}
 
 			// All interpolators should return FactorMin at InputMin
@@ -507,12 +436,11 @@ func BenchmarkEaseInInterpolation(b *testing.B) {
 
 func BenchmarkWeatherScalerScale(b *testing.B) {
 	scaler := &WeatherScaler{
-		Enabled:       true,
 		Interpolation: EaseInOut,
-		InputMin:      0.0,
-		InputMax:      100.0,
-		FactorMin:     0.5,
-		FactorMax:     1.5,
+		InputMin:      float64Ptr(0.0),
+		InputMax:      float64Ptr(100.0),
+		FactorMin:     float64Ptr(0.5),
+		FactorMax:     float64Ptr(1.5),
 	}
 	for i := 0; i < b.N; i++ {
 		scaler.Scale(50.0)

--- a/garden-app/pkg/weather/scaler_test.go
+++ b/garden-app/pkg/weather/scaler_test.go
@@ -1,0 +1,520 @@
+package weather
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test interpolation modes with table-driven tests
+func TestInterpolators(t *testing.T) {
+	tests := []struct {
+		name         string
+		interpolator Interpolator
+		t            float64
+		expected     float64
+		tolerance    float64
+	}{
+		// Linear interpolation tests
+		{"linear at 0", LinearInterpolator{}, 0.0, 0.0, 0.0001},
+		{"linear at 0.25", LinearInterpolator{}, 0.25, 0.25, 0.0001},
+		{"linear at 0.5", LinearInterpolator{}, 0.5, 0.5, 0.0001},
+		{"linear at 0.75", LinearInterpolator{}, 0.75, 0.75, 0.0001},
+		{"linear at 1", LinearInterpolator{}, 1.0, 1.0, 0.0001},
+
+		// Ease-in interpolation tests (t²)
+		{"ease_in at 0", EaseInInterpolator{}, 0.0, 0.0, 0.0001},
+		{"ease_in at 0.25", EaseInInterpolator{}, 0.25, 0.0625, 0.0001},
+		{"ease_in at 0.5", EaseInInterpolator{}, 0.5, 0.25, 0.0001},
+		{"ease_in at 0.75", EaseInInterpolator{}, 0.75, 0.5625, 0.0001},
+		{"ease_in at 1", EaseInInterpolator{}, 1.0, 1.0, 0.0001},
+
+		// Ease-out interpolation tests (1 - (1-t)²)
+		{"ease_out at 0", EaseOutInterpolator{}, 0.0, 0.0, 0.0001},
+		{"ease_out at 0.25", EaseOutInterpolator{}, 0.25, 0.4375, 0.0001},
+		{"ease_out at 0.5", EaseOutInterpolator{}, 0.5, 0.75, 0.0001},
+		{"ease_out at 0.75", EaseOutInterpolator{}, 0.75, 0.9375, 0.0001},
+		{"ease_out at 1", EaseOutInterpolator{}, 1.0, 1.0, 0.0001},
+
+		// Ease-in-out interpolation tests
+		{"ease_in_out at 0", EaseInOutInterpolator{}, 0.0, 0.0, 0.0001},
+		{"ease_in_out at 0.25", EaseInOutInterpolator{}, 0.25, 0.125, 0.0001},
+		{"ease_in_out at 0.5", EaseInOutInterpolator{}, 0.5, 0.5, 0.0001},
+		{"ease_in_out at 0.75", EaseInOutInterpolator{}, 0.75, 0.875, 0.0001},
+		{"ease_in_out at 1", EaseInOutInterpolator{}, 1.0, 1.0, 0.0001},
+
+		// Step interpolation tests
+		{"step at 0", StepInterpolator{}, 0.0, 0.0, 0.0001},
+		{"step at 0.5", StepInterpolator{}, 0.5, 0.0, 0.0001},
+		{"step at 0.99", StepInterpolator{}, 0.99, 0.0, 0.0001},
+		{"step at 1", StepInterpolator{}, 1.0, 1.0, 0.0001},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.interpolator.Interpolate(tt.t)
+			assert.InDelta(t, tt.expected, result, tt.tolerance,
+				"Interpolate(%v) expected %v but got %v", tt.t, tt.expected, result)
+		})
+	}
+}
+
+// Test ease_in_out symmetry property
+func TestEaseInOutSymmetry(t *testing.T) {
+	interpolator := EaseInOutInterpolator{}
+
+	// Test symmetry: f(t) + f(1-t) should equal 1
+	for val := 0.0; val <= 1.0; val += 0.1 {
+		f1 := interpolator.Interpolate(val)
+		f2 := interpolator.Interpolate(1 - val)
+		assert.InDelta(t, 1.0, f1+f2, 0.0001,
+			"Symmetry check failed at t=%v: f(t)=%v, f(1-t)=%v", val, f1, f2)
+	}
+}
+
+// Test GetInterpolator factory function
+func TestGetInterpolator(t *testing.T) {
+	tests := []struct {
+		mode     InterpolationMode
+		expected Interpolator
+	}{
+		{Linear, LinearInterpolator{}},
+		{EaseIn, EaseInInterpolator{}},
+		{EaseOut, EaseOutInterpolator{}},
+		{EaseInOut, EaseInOutInterpolator{}},
+		{Step, StepInterpolator{}},
+		{"invalid", LinearInterpolator{}}, // defaults to linear
+		{"", LinearInterpolator{}},        // empty defaults to linear
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.mode), func(t *testing.T) {
+			result := GetInterpolator(tt.mode)
+			assert.IsType(t, tt.expected, result)
+		})
+	}
+}
+
+// Test InterpolationMode.IsValid
+func TestInterpolationModeIsValid(t *testing.T) {
+	tests := []struct {
+		mode     InterpolationMode
+		expected bool
+	}{
+		{Linear, true},
+		{EaseIn, true},
+		{EaseOut, true},
+		{EaseInOut, true},
+		{Step, true},
+		{"invalid", false},
+		{"", false},
+		{"LINEAR", false}, // case sensitive
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.mode), func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.mode.IsValid())
+		})
+	}
+}
+
+// Test WeatherScaler Scale method with clamping
+func TestWeatherScalerClamping(t *testing.T) {
+	scaler := &WeatherScaler{
+		Enabled:       true,
+		Interpolation: Linear,
+		InputMin:      10.0,
+		InputMax:      50.0,
+		FactorMin:     0.5,
+		FactorMax:     1.5,
+	}
+
+	tests := []struct {
+		name     string
+		input    float64
+		expected float64
+	}{
+		{"below min", 5.0, 0.5},
+		{"at min", 10.0, 0.5},
+		{"above max", 60.0, 1.5},
+		{"at max", 50.0, 1.5},
+		{"midpoint", 30.0, 1.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := scaler.Scale(tt.input)
+			assert.InDelta(t, tt.expected, result, 0.0001)
+		})
+	}
+}
+
+// Test disabled WeatherScaler returns 1.0
+func TestWeatherScalerDisabled(t *testing.T) {
+	scaler := &WeatherScaler{
+		Enabled:       false,
+		Interpolation: Linear,
+		InputMin:      10.0,
+		InputMax:      50.0,
+		FactorMin:     0.5,
+		FactorMax:     1.5,
+	}
+
+	// Should return 1.0 regardless of input when disabled
+	assert.InDelta(t, 1.0, scaler.Scale(5.0), 0.0001)
+	assert.InDelta(t, 1.0, scaler.Scale(30.0), 0.0001)
+	assert.InDelta(t, 1.0, scaler.Scale(60.0), 0.0001)
+}
+
+// Scenario 1: Rain Scaler - Input: 0-30mm, Output: 1.0-0.0 (linear)
+func TestRainScenario(t *testing.T) {
+	rainScaler := &WeatherScaler{
+		Enabled:       true,
+		Interpolation: Linear,
+		InputMin:      0.0,
+		InputMax:      30.0,
+		FactorMin:     1.0,
+		FactorMax:     0.0,
+	}
+
+	tests := []struct {
+		input    float64
+		expected float64
+	}{
+		{0.0, 1.0},
+		{15.0, 0.5},
+		{30.0, 0.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("rain_%vmm", tt.input), func(t *testing.T) {
+			result := rainScaler.Scale(tt.input)
+			assert.InDelta(t, tt.expected, result, 0.0001)
+		})
+	}
+}
+
+// Scenario 2: Temperature Scaler - Input: 20-46°C, Output: 1.0-1.5 (ease_in)
+func TestTemperatureScenario(t *testing.T) {
+	tempScaler := &WeatherScaler{
+		Enabled:       true,
+		Interpolation: EaseIn,
+		InputMin:      20.0,
+		InputMax:      46.0,
+		FactorMin:     1.0,
+		FactorMax:     1.5,
+	}
+
+	// Manual calculation verification
+	t.Run("20C", func(t *testing.T) {
+		assert.InDelta(t, 1.0, tempScaler.Scale(20.0), 0.0001)
+	})
+	t.Run("33C", func(t *testing.T) {
+		// t = (33-20)/(46-20) = 0.5
+		// ease_in(0.5) = 0.25
+		// result = 1.0 + 0.5*0.25 = 1.125
+		assert.InDelta(t, 1.125, tempScaler.Scale(33.0), 0.0001)
+	})
+	t.Run("46C", func(t *testing.T) {
+		assert.InDelta(t, 1.5, tempScaler.Scale(46.0), 0.0001)
+	})
+}
+
+// Test multi-scaler multiplication
+func TestScaleMulti(t *testing.T) {
+	rainScaler := &WeatherScaler{
+		Enabled:       true,
+		Interpolation: Linear,
+		InputMin:      0.0,
+		InputMax:      30.0,
+		FactorMin:     1.0,
+		FactorMax:     0.0,
+	}
+
+	tempScaler := &WeatherScaler{
+		Enabled:       true,
+		Interpolation: Linear,
+		InputMin:      20.0,
+		InputMax:      46.0,
+		FactorMin:     1.0,
+		FactorMax:     1.5,
+	}
+
+	// rain: 6mm -> t=0.2 -> 0.8, temp: 30C -> t=(30-20)/26=10/26 -> 1.0+0.5*(10/26)=1.1923...
+	// expected: 0.8 * 1.192307... = 0.953846...
+	scalers := []*WeatherScaler{rainScaler, tempScaler}
+	inputs := []float64{6.0, 30.0}
+
+	result := ScaleMulti(scalers, inputs)
+	assert.InDelta(t, 0.953846, result, 0.0001)
+}
+
+// Test multi-scaler with disabled scaler
+func TestScaleMultiWithDisabled(t *testing.T) {
+	enabledScaler := &WeatherScaler{
+		Enabled:       true,
+		Interpolation: Linear,
+		InputMin:      0.0,
+		InputMax:      10.0,
+		FactorMin:     0.5,
+		FactorMax:     1.0,
+	}
+
+	disabledScaler := &WeatherScaler{
+		Enabled:       false,
+		Interpolation: Linear,
+		InputMin:      0.0,
+		InputMax:      10.0,
+		FactorMin:     0.5,
+		FactorMax:     1.0,
+	}
+
+	// enabled: 0.5 (at InputMin), disabled: 1.0 → expected: 0.5
+	scalers := []*WeatherScaler{enabledScaler, disabledScaler}
+	inputs := []float64{0.0, 5.0}
+
+	result := ScaleMulti(scalers, inputs)
+	assert.InDelta(t, 0.5, result, 0.0001)
+}
+
+// Test ScaleMulti with mismatched lengths
+func TestScaleMultiMismatchedLengths(t *testing.T) {
+	scaler := &WeatherScaler{
+		Enabled:       true,
+		Interpolation: Linear,
+		InputMin:      0.0,
+		InputMax:      10.0,
+		FactorMin:     0.5,
+		FactorMax:     1.0,
+	}
+
+	// Mismatched lengths should return 1.0
+	result := ScaleMulti([]*WeatherScaler{scaler}, []float64{5.0, 10.0})
+	assert.InDelta(t, 1.0, result, 0.0001)
+}
+
+// Test Validation
+func TestWeatherScalerValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		scaler    WeatherScaler
+		wantError bool
+		errMsg    string
+	}{
+		{
+			name: "valid config",
+			scaler: WeatherScaler{
+				Enabled:       true,
+				Interpolation: Linear,
+				InputMin:      0.0,
+				InputMax:      10.0,
+				FactorMin:     0.5,
+				FactorMax:     1.5,
+			},
+			wantError: false,
+		},
+		{
+			name: "disabled scaler skips validation",
+			scaler: WeatherScaler{
+				Enabled:       false,
+				Interpolation: "invalid",
+				InputMin:      10.0,
+				InputMax:      0.0,  // invalid but ignored
+				FactorMin:     -1.0, // invalid but ignored
+				FactorMax:     1.0,
+			},
+			wantError: false,
+		},
+		{
+			name: "input_max <= input_min",
+			scaler: WeatherScaler{
+				Enabled:       true,
+				Interpolation: Linear,
+				InputMin:      10.0,
+				InputMax:      10.0,
+				FactorMin:     0.5,
+				FactorMax:     1.5,
+			},
+			wantError: true,
+			errMsg:    "input_max must be greater than input_min",
+		},
+		{
+			name: "negative FactorMin",
+			scaler: WeatherScaler{
+				Enabled:       true,
+				Interpolation: Linear,
+				InputMin:      0.0,
+				InputMax:      10.0,
+				FactorMin:     -0.5,
+				FactorMax:     1.5,
+			},
+			wantError: true,
+			errMsg:    "factors must be non-negative",
+		},
+		{
+			name: "negative FactorMax",
+			scaler: WeatherScaler{
+				Enabled:       true,
+				Interpolation: Linear,
+				InputMin:      0.0,
+				InputMax:      10.0,
+				FactorMin:     0.5,
+				FactorMax:     -1.5,
+			},
+			wantError: true,
+			errMsg:    "factors must be non-negative",
+		},
+		{
+			name: "invalid interpolation mode",
+			scaler: WeatherScaler{
+				Enabled:       true,
+				Interpolation: "invalid_mode",
+				InputMin:      0.0,
+				InputMax:      10.0,
+				FactorMin:     0.5,
+				FactorMax:     1.5,
+			},
+			wantError: true,
+			errMsg:    "invalid interpolation mode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.scaler.Validate()
+			if tt.wantError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Test edge cases
+func TestWeatherScalerEdgeCases(t *testing.T) {
+	t.Run("flat line - FactorMin equals FactorMax", func(t *testing.T) {
+		scaler := &WeatherScaler{
+			Enabled:       true,
+			Interpolation: Linear,
+			InputMin:      0.0,
+			InputMax:      10.0,
+			FactorMin:     0.5,
+			FactorMax:     0.5,
+		}
+
+		// Should always return 0.5 regardless of input
+		assert.InDelta(t, 0.5, scaler.Scale(0.0), 0.0001)
+		assert.InDelta(t, 0.5, scaler.Scale(5.0), 0.0001)
+		assert.InDelta(t, 0.5, scaler.Scale(10.0), 0.0001)
+	})
+
+	t.Run("very large input range", func(t *testing.T) {
+		scaler := &WeatherScaler{
+			Enabled:       true,
+			Interpolation: Linear,
+			InputMin:      0.0,
+			InputMax:      1e9,
+			FactorMin:     0.0,
+			FactorMax:     1.0,
+		}
+
+		assert.InDelta(t, 0.5, scaler.Scale(5e8), 0.0001)
+	})
+
+	t.Run("very small input range", func(t *testing.T) {
+		scaler := &WeatherScaler{
+			Enabled:       true,
+			Interpolation: Linear,
+			InputMin:      0.0,
+			InputMax:      0.001,
+			FactorMin:     0.0,
+			FactorMax:     1.0,
+		}
+
+		assert.InDelta(t, 0.5, scaler.Scale(0.0005), 0.0001)
+	})
+}
+
+// Test floating point precision
+func TestFloatingPointPrecision(t *testing.T) {
+	scaler := &WeatherScaler{
+		Enabled:       true,
+		Interpolation: Linear,
+		InputMin:      0.0,
+		InputMax:      1.0,
+		FactorMin:     0.0,
+		FactorMax:     1.0,
+	}
+
+	// Test that results are precise
+	for i := 0; i <= 100; i++ {
+		input := float64(i) / 100.0
+		result := scaler.Scale(input)
+		expected := input
+		assert.InDelta(t, expected, result, 0.0001,
+			"Precision test failed at input %v", input)
+	}
+}
+
+// Test with all interpolation modes
+func TestAllInterpolationModes(t *testing.T) {
+	modes := []InterpolationMode{Linear, EaseIn, EaseOut, EaseInOut, Step}
+
+	for _, mode := range modes {
+		t.Run(string(mode), func(t *testing.T) {
+			scaler := &WeatherScaler{
+				Enabled:       true,
+				Interpolation: mode,
+				InputMin:      0.0,
+				InputMax:      10.0,
+				FactorMin:     0.0,
+				FactorMax:     1.0,
+			}
+
+			// All interpolators should return FactorMin at InputMin
+			assert.InDelta(t, 0.0, scaler.Scale(0.0), 0.0001)
+
+			// All interpolators should return FactorMax at InputMax
+			assert.InDelta(t, 1.0, scaler.Scale(10.0), 0.0001)
+
+			// All interpolators should return values in valid range
+			for input := 0.0; input <= 10.0; input += 1.0 {
+				result := scaler.Scale(input)
+				assert.True(t, result >= 0.0 && result <= 1.0,
+					"Result %v out of bounds for input %v", result, input)
+			}
+		})
+	}
+}
+
+// Benchmark interpolation functions
+func BenchmarkLinearInterpolation(b *testing.B) {
+	interpolator := LinearInterpolator{}
+	for i := 0; i < b.N; i++ {
+		interpolator.Interpolate(0.5)
+	}
+}
+
+func BenchmarkEaseInInterpolation(b *testing.B) {
+	interpolator := EaseInInterpolator{}
+	for i := 0; i < b.N; i++ {
+		interpolator.Interpolate(0.5)
+	}
+}
+
+func BenchmarkWeatherScalerScale(b *testing.B) {
+	scaler := &WeatherScaler{
+		Enabled:       true,
+		Interpolation: EaseInOut,
+		InputMin:      0.0,
+		InputMax:      100.0,
+		FactorMin:     0.5,
+		FactorMax:     1.5,
+	}
+	for i := 0; i < b.N; i++ {
+		scaler.Scale(50.0)
+	}
+}

--- a/garden-app/server/templates.go
+++ b/garden-app/server/templates.go
@@ -168,6 +168,9 @@ func templateFuncs(r *http.Request) map[string]any {
 			}
 			return *f
 		},
+		"Float64Ptr": func(f float64) *float64 {
+			return &f
+		},
 		"timeNow": func() time.Time {
 			return clock.Now()
 		},

--- a/garden-app/server/templates.go
+++ b/garden-app/server/templates.go
@@ -63,6 +63,9 @@ const (
 
 	// User settings templates
 	unitsSelectorTemplate html.Template = "UnitsSelector"
+
+	// Scaling example results template
+	scalingExampleResultsTemplate html.Template = "ScalingExampleResults"
 )
 
 func templateFuncs(r *http.Request) map[string]any {
@@ -106,14 +109,26 @@ func templateFuncs(r *http.Request) map[string]any {
 		},
 		"Sprintf": fmt.Sprintf,
 		"CelsiusToFahrenheit": func(c any) float64 {
+			var f float64
 			switch v := c.(type) {
 			case float64:
-				return v*1.8 + 32
+				f = v
 			case float32:
-				return float64(v)*1.8 + 32
+				f = float64(v)
+			case *float64:
+				if v == nil {
+					return 0
+				}
+				f = *v
+			case *float32:
+				if v == nil {
+					return 0
+				}
+				f = float64(*v)
 			default:
 				return 0
 			}
+			return f*1.8 + 32
 		},
 		"MmToInches": func(val any) float64 {
 			var f float64
@@ -167,6 +182,15 @@ func templateFuncs(r *http.Request) map[string]any {
 				return 0
 			}
 			return *f
+		},
+		"DerefFloat64": func(f *float64) float64 {
+			if f == nil {
+				return 0
+			}
+			return *f
+		},
+		"IsNotNil": func(v any) bool {
+			return v != nil
 		},
 		"Float64Ptr": func(f float64) *float64 {
 			return &f

--- a/garden-app/server/templates/base.html
+++ b/garden-app/server/templates/base.html
@@ -180,6 +180,215 @@
             }
         });
 
+        // Scaling Chart Functions
+        const ScalingInterpolation = {
+            linear: t => t,
+            ease_in: t => t * t,
+            ease_out: t => 1 - Math.pow(1 - t, 2),
+            ease_in_out: t => t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2,
+            step: t => t < 1 ? 0 : 1
+        };
+
+        function generateScalingCurveSVG(inputMin, inputMax, factorMin, factorMax, mode, width, height) {
+            // Validate inputs
+            if (inputMin === '' || inputMax === '' || factorMin === '' || factorMax === '' || !mode) {
+                return null;
+            }
+            
+            const iMin = parseFloat(inputMin);
+            const iMax = parseFloat(inputMax);
+            const fMin = parseFloat(factorMin);
+            const fMax = parseFloat(factorMax);
+            
+            if (isNaN(iMin) || isNaN(iMax) || isNaN(fMin) || isNaN(fMax)) {
+                return null;
+            }
+            
+            const interpolate = ScalingInterpolation[mode] || ScalingInterpolation.linear;
+            const padding = { top: 10, right: 10, bottom: 25, left: 35 };
+            const chartWidth = width - padding.left - padding.right;
+            const chartHeight = height - padding.top - padding.bottom;
+            
+            // Determine Y range (round to nice numbers)
+            const yMin = Math.min(fMin, fMax);
+            const yMax = Math.max(fMin, fMax);
+            const yPadding = (yMax - yMin) * 0.1 || 0.5;
+            const yRangeMin = Math.max(0, yMin - yPadding);
+            const yRangeMax = yMax + yPadding;
+            
+            // Generate points
+            const numPoints = 30;
+            let pathData = '';
+            
+            for (let i = 0; i <= numPoints; i++) {
+                const t = i / numPoints;
+                const inputValue = iMin + t * (iMax - iMin);
+                const factorT = interpolate(t);
+                const factorValue = fMin + factorT * (fMax - fMin);
+                
+                const x = padding.left + t * chartWidth;
+                const y = padding.top + chartHeight - ((factorValue - yRangeMin) / (yRangeMax - yRangeMin)) * chartHeight;
+                
+                if (i === 0) {
+                    pathData += `M ${x} ${y}`;
+                } else {
+                    pathData += ` L ${x} ${y}`;
+                }
+            }
+            
+            // Format numbers nicely
+            const fmt = (n) => {
+                if (Math.abs(n) >= 100) return Math.round(n).toString();
+                if (Math.abs(n) >= 10) return n.toFixed(1);
+                if (Math.abs(n) >= 1) return n.toFixed(2);
+                return n.toFixed(3);
+            };
+            
+            // Create SVG
+            const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+            svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+            svg.setAttribute('class', 'scaling-chart');
+            svg.style.width = '100%';
+            svg.style.height = 'auto';
+            svg.style.maxWidth = '350px';
+            
+            // Grid lines (horizontal)
+            const numGridLines = 4;
+            for (let i = 0; i <= numGridLines; i++) {
+                const yVal = yRangeMin + (i / numGridLines) * (yRangeMax - yRangeMin);
+                const y = padding.top + chartHeight - (i / numGridLines) * chartHeight;
+                
+                const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+                line.setAttribute('x1', padding.left);
+                line.setAttribute('y1', y);
+                line.setAttribute('x2', padding.left + chartWidth);
+                line.setAttribute('y2', y);
+                line.setAttribute('stroke', '#e5e5e5');
+                line.setAttribute('stroke-width', '1');
+                svg.appendChild(line);
+                
+                // Y-axis label
+                const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+                text.setAttribute('x', padding.left - 5);
+                text.setAttribute('y', y + 3);
+                text.setAttribute('text-anchor', 'end');
+                text.setAttribute('font-size', '10');
+                text.setAttribute('fill', '#999');
+                text.textContent = fmt(yVal);
+                svg.appendChild(text);
+            }
+            
+            // Grid lines (vertical - just at min/max)
+            [0, 1].forEach(t => {
+                const x = padding.left + t * chartWidth;
+                const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+                line.setAttribute('x1', x);
+                line.setAttribute('y1', padding.top);
+                line.setAttribute('x2', x);
+                line.setAttribute('y2', padding.top + chartHeight);
+                line.setAttribute('stroke', '#e5e5e5');
+                line.setAttribute('stroke-width', '1');
+                svg.appendChild(line);
+            });
+            
+            // X-axis labels
+            const xLabels = [fmt(iMin), fmt(iMax)];
+            xLabels.forEach((label, i) => {
+                const x = padding.left + i * chartWidth;
+                const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+                text.setAttribute('x', x);
+                text.setAttribute('y', height - 5);
+                text.setAttribute('text-anchor', i === 0 ? 'start' : 'end');
+                text.setAttribute('font-size', '10');
+                text.setAttribute('fill', '#999');
+                text.textContent = label;
+                svg.appendChild(text);
+            });
+            
+            // Curve path
+            const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            path.setAttribute('d', pathData);
+            path.setAttribute('fill', 'none');
+            path.setAttribute('stroke', '#1e87f0');
+            path.setAttribute('stroke-width', '2.5');
+            path.setAttribute('stroke-linecap', 'round');
+            path.setAttribute('stroke-linejoin', 'round');
+            svg.appendChild(path);
+            
+            // Axis lines
+            const xAxis = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+            xAxis.setAttribute('x1', padding.left);
+            xAxis.setAttribute('y1', padding.top + chartHeight);
+            xAxis.setAttribute('x2', padding.left + chartWidth);
+            xAxis.setAttribute('y2', padding.top + chartHeight);
+            xAxis.setAttribute('stroke', '#ccc');
+            xAxis.setAttribute('stroke-width', '1');
+            svg.appendChild(xAxis);
+            
+            const yAxis = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+            yAxis.setAttribute('x1', padding.left);
+            yAxis.setAttribute('y1', padding.top);
+            yAxis.setAttribute('x2', padding.left);
+            yAxis.setAttribute('y2', padding.top + chartHeight);
+            yAxis.setAttribute('stroke', '#ccc');
+            yAxis.setAttribute('stroke-width', '1');
+            svg.appendChild(yAxis);
+            
+            return svg;
+        }
+
+        function updateScalingCharts() {
+            // Rain chart
+            const rainChartContainer = document.getElementById('rain-scaling-chart');
+            if (rainChartContainer && !document.getElementById('rain-fields').classList.contains('uk-hidden')) {
+                const rainInputs = {
+                    inputMin: document.getElementById('rain-input-min')?.value,
+                    inputMax: document.getElementById('rain-input-max')?.value,
+                    factorMin: document.getElementById('rain-factor-min')?.value,
+                    factorMax: document.getElementById('rain-factor-max')?.value,
+                    mode: document.getElementById('rain-interpolation')?.value
+                };
+                
+                const rainSVG = generateScalingCurveSVG(
+                    rainInputs.inputMin, rainInputs.inputMax,
+                    rainInputs.factorMin, rainInputs.factorMax,
+                    rainInputs.mode, 300, 150
+                );
+                
+                rainChartContainer.innerHTML = '';
+                if (rainSVG) {
+                    rainChartContainer.appendChild(rainSVG);
+                } else {
+                    rainChartContainer.innerHTML = '<div class="uk-text-muted uk-text-center" style="line-height: 150px;">Enter values to see curve</div>';
+                }
+            }
+            
+            // Temperature chart
+            const tempChartContainer = document.getElementById('temperature-scaling-chart');
+            if (tempChartContainer && !document.getElementById('temperature-fields').classList.contains('uk-hidden')) {
+                const tempInputs = {
+                    inputMin: document.getElementById('temperature-input-min')?.value,
+                    inputMax: document.getElementById('temperature-input-max')?.value,
+                    factorMin: document.getElementById('temperature-factor-min')?.value,
+                    factorMax: document.getElementById('temperature-factor-max')?.value,
+                    mode: document.getElementById('temperature-interpolation')?.value
+                };
+                
+                const tempSVG = generateScalingCurveSVG(
+                    tempInputs.inputMin, tempInputs.inputMax,
+                    tempInputs.factorMin, tempInputs.factorMax,
+                    tempInputs.mode, 300, 150
+                );
+                
+                tempChartContainer.innerHTML = '';
+                if (tempSVG) {
+                    tempChartContainer.appendChild(tempSVG);
+                } else {
+                    tempChartContainer.innerHTML = '<div class="uk-text-muted uk-text-center" style="line-height: 150px;">Enter values to see curve</div>';
+                }
+            }
+        }
+
         // Modal close handlers for ESC key and clicking outside
         document.addEventListener('keydown', function(evt) {
             if (evt.key === 'Escape') {

--- a/garden-app/server/templates/base.html
+++ b/garden-app/server/templates/base.html
@@ -25,6 +25,7 @@
 <body>
     <div id="create-modal-here"></div>
     <div id="settings-modal-here"></div>
+    <div id="notification-area" style="position: fixed; top: 70px; left: 50%; transform: translateX(-50%); z-index: 2000; width: 90%; max-width: 800px;"></div>
     <nav class="uk-navbar-container">
         <div class="uk-container">
             <div uk-navbar>

--- a/garden-app/server/templates/water_schedule_modal.html
+++ b/garden-app/server/templates/water_schedule_modal.html
@@ -65,13 +65,26 @@
             </div>
 
             <!-- Rain Scaling Section -->
-            <div class="uk-margin">
-                <label>
-                    <input class="uk-checkbox" type="checkbox" id="rain-scaling-checkbox"
-                        {{ if and .WeatherControl .WeatherControl.Rain }}checked{{ end }}
-                        _="on change if my.checked remove .uk-hidden from #rain-fields then remove @disabled from <#rain-fields input, #rain-fields select/> else set <#rain-fields input/>'s value to '' then set #rain-client-select's selectedIndex to -1 then add @disabled to <#rain-fields input, #rain-fields select/> then add .uk-hidden to #rain-fields">
-                    Enable Rain Scaling
-                </label>
+            <div class="uk-margin" style="text-align: left;">
+                <button type="button" id="rain-scaling-toggle" 
+                    class="uk-button {{ if and .WeatherControl .WeatherControl.Rain }}uk-button-primary{{ else }}uk-button-default{{ end }}"
+                    _="on click 
+                        if #rain-fields.classList.contains('uk-hidden') then 
+                            remove .uk-hidden from #rain-fields 
+                            then remove @disabled from <#rain-fields input, #rain-fields select/> 
+                            then add .uk-button-primary to me 
+                            then remove .uk-button-default from me
+                            then remove .uk-hidden from #scaling-preview-section
+                        else 
+                            set <#rain-fields input/>'s value to '' 
+                            then set #rain-client-select's selectedIndex to -1 
+                            then add @disabled to <#rain-fields input, #rain-fields select/> 
+                            then add .uk-hidden to #rain-fields 
+                            then add .uk-button-default to me 
+                            then remove .uk-button-primary from me
+                            then if #temperature-fields.classList.contains('uk-hidden') then add .uk-hidden to #scaling-preview-section end">
+                    {{ if and .WeatherControl .WeatherControl.Rain }}Disable{{ else }}Enable{{ end }} Rain Scaling
+                </button>
             </div>
             <div id="rain-fields" class="{{ if or (eq .WeatherControl nil) (eq .WeatherControl.Rain nil) }}uk-hidden{{ end }}">
                 <div class="uk-margin">
@@ -79,7 +92,7 @@
                     <select id="rain-client-select" class="uk-select" name="WeatherControl.Rain.ClientID" required
                         {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Rain nil) }}disabled{{ end }}>
                         {{ range .WeatherClients }}
-                        <option value="{{ .ID }}" {{ if and $.WeatherControl $.WeatherControl.Rain (eq .ID.String $.WeatherControl.Rain.ClientID) }}selected{{ end }}>{{ .Name }}</option>
+                        <option value="{{ .ID }}" {{ if and $.WeatherControl $.WeatherControl.Rain (eq .ID.ID $.WeatherControl.Rain.ClientID) }}selected{{ end }}>{{ .Name }}</option>
                         {{ end }}
                     </select>
                 </div>
@@ -87,21 +100,21 @@
                     <div>
                         <label class="uk-form-label" for="rain-input-min">Input Min ({{ if IsMetric }}mm{{ else }}in{{ end }})*</label>
                         <input id="rain-input-min" class="uk-input" type="number" step="0.01" required
-                            value="{{ if and .WeatherControl .WeatherControl.Rain }}{{ if IsMetric }}{{ printf "%.2f" .WeatherControl.Rain.InputMin }}{{ else }}{{ printf "%.2f" (MmToInches (Float64Ptr .WeatherControl.Rain.InputMin)) }}{{ end }}{{ end }}"
+                            value="{{ if and .WeatherControl .WeatherControl.Rain (IsNotNil .WeatherControl.Rain.InputMin) }}{{ if IsMetric }}{{ printf "%.2f" (DerefFloat64 .WeatherControl.Rain.InputMin) }}{{ else }}{{ printf "%.2f" (MmToInches .WeatherControl.Rain.InputMin) }}{{ end }}{{ end }}"
                             name="WeatherControl.Rain.InputMin"
                             {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Rain nil) }}disabled{{ end }}>
                     </div>
                     <div>
                         <label class="uk-form-label" for="rain-input-max">Input Max ({{ if IsMetric }}mm{{ else }}in{{ end }})*</label>
                         <input id="rain-input-max" class="uk-input" type="number" step="0.01" required
-                            value="{{ if and .WeatherControl .WeatherControl.Rain }}{{ if IsMetric }}{{ printf "%.2f" .WeatherControl.Rain.InputMax }}{{ else }}{{ printf "%.2f" (MmToInches (Float64Ptr .WeatherControl.Rain.InputMax)) }}{{ end }}{{ end }}"
+                            value="{{ if and .WeatherControl .WeatherControl.Rain (IsNotNil .WeatherControl.Rain.InputMax) }}{{ if IsMetric }}{{ printf "%.2f" (DerefFloat64 .WeatherControl.Rain.InputMax) }}{{ else }}{{ printf "%.2f" (MmToInches .WeatherControl.Rain.InputMax) }}{{ end }}{{ end }}"
                             name="WeatherControl.Rain.InputMax"
                             {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Rain nil) }}disabled{{ end }}>
                     </div>
                     <div>
                         <label class="uk-form-label" for="rain-factor-min">Factor Min*</label>
                         <input id="rain-factor-min" class="uk-input" type="number" step="0.01" min="0" required
-                            value="{{ if and .WeatherControl .WeatherControl.Rain }}{{ printf "%.2f" .WeatherControl.Rain.FactorMin }}{{ end }}"
+                            value="{{ if and .WeatherControl .WeatherControl.Rain (IsNotNil .WeatherControl.Rain.FactorMin) }}{{ printf "%.2f" (DerefFloat64 .WeatherControl.Rain.FactorMin) }}{{ end }}"
                             name="WeatherControl.Rain.FactorMin"
                             {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Rain nil) }}disabled{{ end }}>
                     </div>
@@ -110,7 +123,7 @@
                     <div>
                         <label class="uk-form-label" for="rain-factor-max">Factor Max*</label>
                         <input id="rain-factor-max" class="uk-input" type="number" step="0.01" min="0" required
-                            value="{{ if and .WeatherControl .WeatherControl.Rain }}{{ printf "%.2f" .WeatherControl.Rain.FactorMax }}{{ end }}"
+                            value="{{ if and .WeatherControl .WeatherControl.Rain (IsNotNil .WeatherControl.Rain.FactorMax) }}{{ printf "%.2f" (DerefFloat64 .WeatherControl.Rain.FactorMax) }}{{ end }}"
                             name="WeatherControl.Rain.FactorMax"
                             {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Rain nil) }}disabled{{ end }}>
                     </div>
@@ -129,13 +142,26 @@
             </div>
 
             <!-- Temperature Scaling Section -->
-            <div class="uk-margin">
-                <label>
-                    <input class="uk-checkbox" type="checkbox" id="temperature-scaling-checkbox"
-                        {{ if and .WeatherControl .WeatherControl.Temperature }}checked{{ end }}
-                        _="on change if my.checked remove .uk-hidden from #temperature-fields then remove @disabled from <#temperature-fields input, #temperature-fields select/> else set <#temperature-fields input/>'s value to '' then set #temperature-client-select's selectedIndex to -1 then add @disabled to <#temperature-fields input, #temperature-fields select/> then add .uk-hidden to #temperature-fields">
-                    Enable Temperature Scaling
-                </label>
+            <div class="uk-margin" style="text-align: left;">
+                <button type="button" id="temperature-scaling-toggle"
+                    class="uk-button {{ if and .WeatherControl .WeatherControl.Temperature }}uk-button-primary{{ else }}uk-button-default{{ end }}"
+                    _="on click
+                        if #temperature-fields.classList.contains('uk-hidden') then
+                            remove .uk-hidden from #temperature-fields
+                            then remove @disabled from <#temperature-fields input, #temperature-fields select/>
+                            then add .uk-button-primary to me
+                            then remove .uk-button-default from me
+                            then remove .uk-hidden from #scaling-preview-section
+                        else
+                            set <#temperature-fields input/>'s value to ''
+                            then set #temperature-client-select's selectedIndex to -1
+                            then add @disabled to <#temperature-fields input, #temperature-fields select/>
+                            then add .uk-hidden to #temperature-fields
+                            then add .uk-button-default to me
+                            then remove .uk-button-primary from me
+                            then if #rain-fields.classList.contains('uk-hidden') then add .uk-hidden to #scaling-preview-section end">
+                    {{ if and .WeatherControl .WeatherControl.Temperature }}Disable{{ else }}Enable{{ end }} Temperature Scaling
+                </button>
             </div>
             <div id="temperature-fields" class="{{ if or (eq .WeatherControl nil) (eq .WeatherControl.Temperature nil) }}uk-hidden{{ end }}">
                 <div class="uk-margin">
@@ -143,7 +169,7 @@
                     <select id="temperature-client-select" class="uk-select" name="WeatherControl.Temperature.ClientID" required
                         {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Temperature nil) }}disabled{{ end }}>
                         {{ range .WeatherClients }}
-                        <option value="{{ .ID }}" {{ if and $.WeatherControl $.WeatherControl.Temperature (eq .ID.String $.WeatherControl.Temperature.ClientID) }}selected{{ end }}>{{ .Name }}</option>
+                        <option value="{{ .ID }}" {{ if and $.WeatherControl $.WeatherControl.Temperature (eq .ID.ID $.WeatherControl.Temperature.ClientID) }}selected{{ end }}>{{ .Name }}</option>
                         {{ end }}
                     </select>
                 </div>
@@ -151,21 +177,21 @@
                     <div>
                         <label class="uk-form-label" for="temperature-input-min">Input Min ({{ if IsMetric }}°C{{ else }}°F{{ end }})*</label>
                         <input id="temperature-input-min" class="uk-input" type="number" step="0.01" required
-                            value="{{ if and .WeatherControl .WeatherControl.Temperature }}{{ if IsMetric }}{{ printf "%.1f" .WeatherControl.Temperature.InputMin }}{{ else }}{{ printf "%.1f" (CelsiusToFahrenheit (Float64Ptr .WeatherControl.Temperature.InputMin)) }}{{ end }}{{ end }}"
+                            value="{{ if and .WeatherControl .WeatherControl.Temperature (IsNotNil .WeatherControl.Temperature.InputMin) }}{{ if IsMetric }}{{ printf "%.1f" (DerefFloat64 .WeatherControl.Temperature.InputMin) }}{{ else }}{{ printf "%.1f" (CelsiusToFahrenheit .WeatherControl.Temperature.InputMin) }}{{ end }}{{ end }}"
                             name="WeatherControl.Temperature.InputMin"
                             {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Temperature nil) }}disabled{{ end }}>
                     </div>
                     <div>
                         <label class="uk-form-label" for="temperature-input-max">Input Max ({{ if IsMetric }}°C{{ else }}°F{{ end }})*</label>
                         <input id="temperature-input-max" class="uk-input" type="number" step="0.01" required
-                            value="{{ if and .WeatherControl .WeatherControl.Temperature }}{{ if IsMetric }}{{ printf "%.1f" .WeatherControl.Temperature.InputMax }}{{ else }}{{ printf "%.1f" (CelsiusToFahrenheit (Float64Ptr .WeatherControl.Temperature.InputMax)) }}{{ end }}{{ end }}"
+                            value="{{ if and .WeatherControl .WeatherControl.Temperature (IsNotNil .WeatherControl.Temperature.InputMax) }}{{ if IsMetric }}{{ printf "%.1f" (DerefFloat64 .WeatherControl.Temperature.InputMax) }}{{ else }}{{ printf "%.1f" (CelsiusToFahrenheit .WeatherControl.Temperature.InputMax) }}{{ end }}{{ end }}"
                             name="WeatherControl.Temperature.InputMax"
                             {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Temperature nil) }}disabled{{ end }}>
                     </div>
                     <div>
                         <label class="uk-form-label" for="temperature-factor-min">Factor Min*</label>
                         <input id="temperature-factor-min" class="uk-input" type="number" step="0.01" min="0" required
-                            value="{{ if and .WeatherControl .WeatherControl.Temperature }}{{ printf "%.2f" .WeatherControl.Temperature.FactorMin }}{{ end }}"
+                            value="{{ if and .WeatherControl .WeatherControl.Temperature (IsNotNil .WeatherControl.Temperature.FactorMin) }}{{ printf "%.2f" (DerefFloat64 .WeatherControl.Temperature.FactorMin) }}{{ end }}"
                             name="WeatherControl.Temperature.FactorMin"
                             {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Temperature nil) }}disabled{{ end }}>
                     </div>
@@ -174,7 +200,7 @@
                     <div>
                         <label class="uk-form-label" for="temperature-factor-max">Factor Max*</label>
                         <input id="temperature-factor-max" class="uk-input" type="number" step="0.01" min="0" required
-                            value="{{ if and .WeatherControl .WeatherControl.Temperature }}{{ printf "%.2f" .WeatherControl.Temperature.FactorMax }}{{ end }}"
+                            value="{{ if and .WeatherControl .WeatherControl.Temperature (IsNotNil .WeatherControl.Temperature.FactorMax) }}{{ printf "%.2f" (DerefFloat64 .WeatherControl.Temperature.FactorMax) }}{{ end }}"
                             name="WeatherControl.Temperature.FactorMax"
                             {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Temperature nil) }}disabled{{ end }}>
                     </div>
@@ -192,6 +218,19 @@
                 </div>
             </div>
 
+            <!-- Scaling Preview Section -->
+            <div id="scaling-preview-section" class="uk-margin {{ if not (or (and .WeatherControl .WeatherControl.Rain) (and .WeatherControl .WeatherControl.Temperature)) }}uk-hidden{{ end }}">
+                <button type="button" class="uk-button uk-button-secondary uk-button-small"
+                    hx-post="/water_schedules/scaling_example"
+                    hx-include="closest form"
+                    hx-target="#scaling-example-results"
+                    hx-swap="innerHTML"
+                    hx-headers='{"Accept": "text/html"}'>
+                    Preview Scaling
+                </button>
+            </div>
+            <div id="scaling-example-results"></div>
+
             <div class="uk-margin-top">
                     {{ template "modalSubmitButton" }}
                 {{ if .Duration }}
@@ -204,6 +243,66 @@
         </form>
     </div>
 </div>
+{{ end }}
+
+{{ define "ScalingExampleResults" }}
+<style>
+#scaling-example-results .uk-alert {
+    transition: none !important;
+}
+#scaling-example-results .uk-alert * {
+    transition: none !important;
+}
+#scaling-example-results .uk-alert.uk-alert-close {
+    opacity: 1 !important;
+    background: none !important;
+}
+</style>
+{{ if or .RainExamples .TemperatureExamples }}
+<div class="uk-alert-primary uk-box-shadow-large" uk-alert style="margin: 0; padding: 20px; max-width: 500px;">
+    <a class="uk-alert-close" uk-close></a>
+    <h4 class="uk-alert-title uk-margin-remove">Scaling Preview <span class="uk-text-small uk-text-muted">({{ .BaseDuration }})</span></h4>
+    
+    {{ if .RainExamples }}
+    <div class="uk-margin-small-top">
+        <div class="uk-text-bold">Rain</div>
+        <table class="uk-table uk-table-justify uk-table-small uk-margin-remove">
+            <tbody>
+                {{ range .RainExamples }}
+                <tr class="uk-padding-remove">
+                    <td class="uk-padding-remove" style="width: 35%;">{{ printf "%.2f" .InputValue }}{{ .InputUnit }}</td>
+                    <td class="uk-padding-remove uk-text-center" style="width: 30%;">{{ printf "%.2f" .ScaleFactor }}x</td>
+                    {{ if .Duration }}<td class="uk-padding-remove uk-text-right" style="width: 35%;">{{ .Duration }}</td>{{ end }}
+                </tr>
+                {{ end }}
+            </tbody>
+        </table>
+    </div>
+    {{ end }}
+    
+    {{ if .TemperatureExamples }}
+    <div class="uk-margin-small-top">
+        <div class="uk-text-bold">Temperature</div>
+        <table class="uk-table uk-table-justify uk-table-small uk-margin-remove">
+            <tbody>
+                {{ range .TemperatureExamples }}
+                <tr class="uk-padding-remove">
+                    <td class="uk-padding-remove" style="width: 35%;">{{ printf "%.1f" .InputValue }}{{ .InputUnit }}</td>
+                    <td class="uk-padding-remove uk-text-center" style="width: 30%;">{{ printf "%.2f" .ScaleFactor }}x</td>
+                    {{ if .Duration }}<td class="uk-padding-remove uk-text-right" style="width: 35%;">{{ .Duration }}</td>{{ end }}
+                </tr>
+                {{ end }}
+            </tbody>
+        </table>
+    </div>
+    {{ end }}
+</div>
+{{ else }}
+<div class="uk-alert-warning uk-box-shadow-large" uk-alert style="margin: 0; padding: 20px; max-width: 500px;">
+    <a class="uk-alert-close" uk-close></a>
+    <p class="uk-margin-remove">Please configure rain or temperature scaling to see a preview.</p>
+</div>
+{{ end }}
 {{ end }}
 
 {{ define "WaterScheduleDetailModal" }}

--- a/garden-app/server/templates/water_schedule_modal.html
+++ b/garden-app/server/templates/water_schedule_modal.html
@@ -79,31 +79,51 @@
                     <select id="rain-client-select" class="uk-select" name="WeatherControl.Rain.ClientID" required
                         {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Rain nil) }}disabled{{ end }}>
                         {{ range .WeatherClients }}
-                        <option value="{{ .ID }}" {{ if and $.WeatherControl $.WeatherControl.Rain (eq .ID.String $.WeatherControl.Rain.ClientID.String) }}selected{{ end }}>{{ .Name }}</option>
+                        <option value="{{ .ID }}" {{ if and $.WeatherControl $.WeatherControl.Rain (eq .ID.String $.WeatherControl.Rain.ClientID) }}selected{{ end }}>{{ .Name }}</option>
                         {{ end }}
                     </select>
                 </div>
                 <div class="uk-grid-small uk-child-width-1-3@s" uk-grid>
                     <div>
-                        <label class="uk-form-label" for="rain-baseline">Baseline ({{ if IsMetric }}mm{{ else }}in{{ end }})*</label>
-                        <input id="rain-baseline" class="uk-input" type="number" step="0.01" required
-                            value="{{ if and .WeatherControl .WeatherControl.Rain .WeatherControl.Rain.BaselineValue }}{{ if IsMetric }}{{ DerefFloat32 .WeatherControl.Rain.BaselineValue }}{{ else }}{{ printf "%.2f" (MmToInches .WeatherControl.Rain.BaselineValue) }}{{ end }}{{ end }}"
-                            name="WeatherControl.Rain.BaselineValue"
+                        <label class="uk-form-label" for="rain-input-min">Input Min ({{ if IsMetric }}mm{{ else }}in{{ end }})*</label>
+                        <input id="rain-input-min" class="uk-input" type="number" step="0.01" required
+                            value="{{ if and .WeatherControl .WeatherControl.Rain }}{{ if IsMetric }}{{ printf "%.2f" .WeatherControl.Rain.InputMin }}{{ else }}{{ printf "%.2f" (MmToInches (Float64Ptr .WeatherControl.Rain.InputMin)) }}{{ end }}{{ end }}"
+                            name="WeatherControl.Rain.InputMin"
                             {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Rain nil) }}disabled{{ end }}>
                     </div>
                     <div>
-                        <label class="uk-form-label" for="rain-factor">Factor*</label>
-                        <input id="rain-factor" class="uk-input" type="number" step="0.01" min="0" max="1" required
-                            value="{{ if and .WeatherControl .WeatherControl.Rain .WeatherControl.Rain.Factor }}{{ DerefFloat32 .WeatherControl.Rain.Factor }}{{ end }}"
-                            name="WeatherControl.Rain.Factor"
+                        <label class="uk-form-label" for="rain-input-max">Input Max ({{ if IsMetric }}mm{{ else }}in{{ end }})*</label>
+                        <input id="rain-input-max" class="uk-input" type="number" step="0.01" required
+                            value="{{ if and .WeatherControl .WeatherControl.Rain }}{{ if IsMetric }}{{ printf "%.2f" .WeatherControl.Rain.InputMax }}{{ else }}{{ printf "%.2f" (MmToInches (Float64Ptr .WeatherControl.Rain.InputMax)) }}{{ end }}{{ end }}"
+                            name="WeatherControl.Rain.InputMax"
                             {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Rain nil) }}disabled{{ end }}>
                     </div>
                     <div>
-                        <label class="uk-form-label" for="rain-range">Range ({{ if IsMetric }}mm{{ else }}in{{ end }})*</label>
-                        <input id="rain-range" class="uk-input" type="number" step="0.01" min="0" required
-                            value="{{ if and .WeatherControl .WeatherControl.Rain .WeatherControl.Rain.Range }}{{ if IsMetric }}{{ DerefFloat32 .WeatherControl.Rain.Range }}{{ else }}{{ printf "%.2f" (MmToInches .WeatherControl.Rain.Range) }}{{ end }}{{ end }}"
-                            name="WeatherControl.Rain.Range"
+                        <label class="uk-form-label" for="rain-factor-min">Factor Min*</label>
+                        <input id="rain-factor-min" class="uk-input" type="number" step="0.01" min="0" required
+                            value="{{ if and .WeatherControl .WeatherControl.Rain }}{{ printf "%.2f" .WeatherControl.Rain.FactorMin }}{{ end }}"
+                            name="WeatherControl.Rain.FactorMin"
                             {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Rain nil) }}disabled{{ end }}>
+                    </div>
+                </div>
+                <div class="uk-grid-small uk-child-width-1-2@s" uk-grid>
+                    <div>
+                        <label class="uk-form-label" for="rain-factor-max">Factor Max*</label>
+                        <input id="rain-factor-max" class="uk-input" type="number" step="0.01" min="0" required
+                            value="{{ if and .WeatherControl .WeatherControl.Rain }}{{ printf "%.2f" .WeatherControl.Rain.FactorMax }}{{ end }}"
+                            name="WeatherControl.Rain.FactorMax"
+                            {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Rain nil) }}disabled{{ end }}>
+                    </div>
+                    <div>
+                        <label class="uk-form-label" for="rain-interpolation">Interpolation*</label>
+                        <select id="rain-interpolation" class="uk-select" name="WeatherControl.Rain.Interpolation" required
+                            {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Rain nil) }}disabled{{ end }}>
+                            <option value="linear" {{ if and .WeatherControl .WeatherControl.Rain (eq .WeatherControl.Rain.Interpolation "linear") }}selected{{ end }}>Linear</option>
+                            <option value="ease_in" {{ if and .WeatherControl .WeatherControl.Rain (eq .WeatherControl.Rain.Interpolation "ease_in") }}selected{{ end }}>Ease In</option>
+                            <option value="ease_out" {{ if and .WeatherControl .WeatherControl.Rain (eq .WeatherControl.Rain.Interpolation "ease_out") }}selected{{ end }}>Ease Out</option>
+                            <option value="ease_in_out" {{ if and .WeatherControl .WeatherControl.Rain (eq .WeatherControl.Rain.Interpolation "ease_in_out") }}selected{{ end }}>Ease In/Out</option>
+                            <option value="step" {{ if and .WeatherControl .WeatherControl.Rain (eq .WeatherControl.Rain.Interpolation "step") }}selected{{ end }}>Step</option>
+                        </select>
                     </div>
                 </div>
             </div>
@@ -123,31 +143,51 @@
                     <select id="temperature-client-select" class="uk-select" name="WeatherControl.Temperature.ClientID" required
                         {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Temperature nil) }}disabled{{ end }}>
                         {{ range .WeatherClients }}
-                        <option value="{{ .ID }}" {{ if and $.WeatherControl $.WeatherControl.Temperature (eq .ID.String $.WeatherControl.Temperature.ClientID.String) }}selected{{ end }}>{{ .Name }}</option>
+                        <option value="{{ .ID }}" {{ if and $.WeatherControl $.WeatherControl.Temperature (eq .ID.String $.WeatherControl.Temperature.ClientID) }}selected{{ end }}>{{ .Name }}</option>
                         {{ end }}
                     </select>
                 </div>
                 <div class="uk-grid-small uk-child-width-1-3@s" uk-grid>
                     <div>
-                        <label class="uk-form-label" for="temperature-baseline">Baseline ({{ if IsMetric }}°C{{ else }}°F{{ end }})*</label>
-                        <input id="temperature-baseline" class="uk-input" type="number" step="0.01" required
-                            value="{{ if and .WeatherControl .WeatherControl.Temperature .WeatherControl.Temperature.BaselineValue }}{{ if IsMetric }}{{ DerefFloat32 .WeatherControl.Temperature.BaselineValue }}{{ else }}{{ printf "%.1f" (CelsiusToFahrenheit (DerefFloat32 .WeatherControl.Temperature.BaselineValue)) }}{{ end }}{{ end }}"
-                            name="WeatherControl.Temperature.BaselineValue"
+                        <label class="uk-form-label" for="temperature-input-min">Input Min ({{ if IsMetric }}°C{{ else }}°F{{ end }})*</label>
+                        <input id="temperature-input-min" class="uk-input" type="number" step="0.01" required
+                            value="{{ if and .WeatherControl .WeatherControl.Temperature }}{{ if IsMetric }}{{ printf "%.1f" .WeatherControl.Temperature.InputMin }}{{ else }}{{ printf "%.1f" (CelsiusToFahrenheit (Float64Ptr .WeatherControl.Temperature.InputMin)) }}{{ end }}{{ end }}"
+                            name="WeatherControl.Temperature.InputMin"
                             {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Temperature nil) }}disabled{{ end }}>
                     </div>
                     <div>
-                        <label class="uk-form-label" for="temperature-factor">Factor*</label>
-                        <input id="temperature-factor" class="uk-input" type="number" step="0.01" min="0" max="1" required
-                            value="{{ if and .WeatherControl .WeatherControl.Temperature .WeatherControl.Temperature.Factor }}{{ DerefFloat32 .WeatherControl.Temperature.Factor }}{{ end }}"
-                            name="WeatherControl.Temperature.Factor"
+                        <label class="uk-form-label" for="temperature-input-max">Input Max ({{ if IsMetric }}°C{{ else }}°F{{ end }})*</label>
+                        <input id="temperature-input-max" class="uk-input" type="number" step="0.01" required
+                            value="{{ if and .WeatherControl .WeatherControl.Temperature }}{{ if IsMetric }}{{ printf "%.1f" .WeatherControl.Temperature.InputMax }}{{ else }}{{ printf "%.1f" (CelsiusToFahrenheit (Float64Ptr .WeatherControl.Temperature.InputMax)) }}{{ end }}{{ end }}"
+                            name="WeatherControl.Temperature.InputMax"
                             {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Temperature nil) }}disabled{{ end }}>
                     </div>
                     <div>
-                        <label class="uk-form-label" for="temperature-range">Range ({{ if IsMetric }}°C{{ else }}°F{{ end }})*</label>
-                        <input id="temperature-range" class="uk-input" type="number" step="0.01" min="0" required
-                            value="{{ if and .WeatherControl .WeatherControl.Temperature .WeatherControl.Temperature.Range }}{{ if IsMetric }}{{ DerefFloat32 .WeatherControl.Temperature.Range }}{{ else }}{{ printf "%.1f" (CelsiusDeltaToFahrenheitDelta .WeatherControl.Temperature.Range) }}{{ end }}{{ end }}"
-                            name="WeatherControl.Temperature.Range"
+                        <label class="uk-form-label" for="temperature-factor-min">Factor Min*</label>
+                        <input id="temperature-factor-min" class="uk-input" type="number" step="0.01" min="0" required
+                            value="{{ if and .WeatherControl .WeatherControl.Temperature }}{{ printf "%.2f" .WeatherControl.Temperature.FactorMin }}{{ end }}"
+                            name="WeatherControl.Temperature.FactorMin"
                             {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Temperature nil) }}disabled{{ end }}>
+                    </div>
+                </div>
+                <div class="uk-grid-small uk-child-width-1-2@s" uk-grid>
+                    <div>
+                        <label class="uk-form-label" for="temperature-factor-max">Factor Max*</label>
+                        <input id="temperature-factor-max" class="uk-input" type="number" step="0.01" min="0" required
+                            value="{{ if and .WeatherControl .WeatherControl.Temperature }}{{ printf "%.2f" .WeatherControl.Temperature.FactorMax }}{{ end }}"
+                            name="WeatherControl.Temperature.FactorMax"
+                            {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Temperature nil) }}disabled{{ end }}>
+                    </div>
+                    <div>
+                        <label class="uk-form-label" for="temperature-interpolation">Interpolation*</label>
+                        <select id="temperature-interpolation" class="uk-select" name="WeatherControl.Temperature.Interpolation" required
+                            {{ if or (eq .WeatherControl nil) (eq .WeatherControl.Temperature nil) }}disabled{{ end }}>
+                            <option value="linear" {{ if and .WeatherControl .WeatherControl.Temperature (eq .WeatherControl.Temperature.Interpolation "linear") }}selected{{ end }}>Linear</option>
+                            <option value="ease_in" {{ if and .WeatherControl .WeatherControl.Temperature (eq .WeatherControl.Temperature.Interpolation "ease_in") }}selected{{ end }}>Ease In</option>
+                            <option value="ease_out" {{ if and .WeatherControl .WeatherControl.Temperature (eq .WeatherControl.Temperature.Interpolation "ease_out") }}selected{{ end }}>Ease Out</option>
+                            <option value="ease_in_out" {{ if and .WeatherControl .WeatherControl.Temperature (eq .WeatherControl.Temperature.Interpolation "ease_in_out") }}selected{{ end }}>Ease In/Out</option>
+                            <option value="step" {{ if and .WeatherControl .WeatherControl.Temperature (eq .WeatherControl.Temperature.Interpolation "step") }}selected{{ end }}>Step</option>
+                        </select>
                     </div>
                 </div>
             </div>

--- a/garden-app/server/templates/water_schedule_modal.html
+++ b/garden-app/server/templates/water_schedule_modal.html
@@ -257,11 +257,33 @@
     opacity: 1 !important;
     background: none !important;
 }
+.scaling-chart-container {
+    background: #f8f8f8;
+    border-radius: 4px;
+    height: 150px;
+    margin-top: 5px;
+}
 </style>
 {{ if or .RainExamples .TemperatureExamples }}
-<div class="uk-alert-primary uk-box-shadow-large" uk-alert style="margin: 0; padding: 20px; max-width: 500px;">
+<div class="uk-alert-primary uk-box-shadow-large" uk-alert style="margin: 0; padding: 20px; max-width: 600px;">
     <a class="uk-alert-close" uk-close></a>
     <h4 class="uk-alert-title uk-margin-remove">Scaling Preview <span class="uk-text-small uk-text-muted">({{ .BaseDuration }})</span></h4>
+    
+    <!-- Charts Section -->
+    <div class="uk-grid uk-grid-small uk-child-width-1-2@l uk-margin-small-top" uk-grid>
+        {{ if .RainExamples }}
+        <div>
+            <div class="uk-text-small uk-text-bold">Rain Scaling Curve</div>
+            <div id="rain-scaling-chart" class="scaling-chart-container"></div>
+        </div>
+        {{ end }}
+        {{ if .TemperatureExamples }}
+        <div>
+            <div class="uk-text-small uk-text-bold">Temperature Scaling Curve</div>
+            <div id="temperature-scaling-chart" class="scaling-chart-container"></div>
+        </div>
+        {{ end }}
+    </div>
     
     {{ if .RainExamples }}
     <div class="uk-margin-small-top">
@@ -297,6 +319,14 @@
     </div>
     {{ end }}
 </div>
+<script>
+    // Generate charts after the preview results are loaded
+    (function() {
+        if (typeof updateScalingCharts === 'function') {
+            updateScalingCharts();
+        }
+    })();
+</script>
 {{ else }}
 <div class="uk-alert-warning uk-box-shadow-large" uk-alert style="margin: 0; padding: 20px; max-width: 500px;">
     <a class="uk-alert-close" uk-close></a>

--- a/garden-app/server/water_schedule.go
+++ b/garden-app/server/water_schedule.go
@@ -174,23 +174,21 @@ func (api *WaterSchedulesAPI) onCreateOrUpdate(_ http.ResponseWriter, r *http.Re
 		// Convert imperial values to metric if user is using imperial units
 		if getUnitsFromRequest(r) == "imperial" {
 			if ws.WeatherControl.Rain != nil {
-				if ws.WeatherControl.Rain.BaselineValue != nil {
-					val := *ws.WeatherControl.Rain.BaselineValue * 25.4 // in → mm
-					ws.WeatherControl.Rain.BaselineValue = &val
+				// Convert rain input range (inches to mm)
+				if ws.WeatherControl.Rain.InputMin != nil {
+					*ws.WeatherControl.Rain.InputMin *= 25.4 // in → mm
 				}
-				if ws.WeatherControl.Rain.Range != nil {
-					val := *ws.WeatherControl.Rain.Range * 25.4 // in → mm
-					ws.WeatherControl.Rain.Range = &val
+				if ws.WeatherControl.Rain.InputMax != nil {
+					*ws.WeatherControl.Rain.InputMax *= 25.4 // in → mm
 				}
 			}
 			if ws.WeatherControl.Temperature != nil {
-				if ws.WeatherControl.Temperature.BaselineValue != nil {
-					val := (*ws.WeatherControl.Temperature.BaselineValue - 32) / 1.8 // °F → °C
-					ws.WeatherControl.Temperature.BaselineValue = &val
+				// Convert temperature input range (°F to °C)
+				if ws.WeatherControl.Temperature.InputMin != nil {
+					*ws.WeatherControl.Temperature.InputMin = (*ws.WeatherControl.Temperature.InputMin - 32) / 1.8 // °F → °C
 				}
-				if ws.WeatherControl.Temperature.Range != nil {
-					val := *ws.WeatherControl.Temperature.Range / 1.8 // °F delta → °C delta
-					ws.WeatherControl.Temperature.Range = &val
+				if ws.WeatherControl.Temperature.InputMax != nil {
+					*ws.WeatherControl.Temperature.InputMax = (*ws.WeatherControl.Temperature.InputMax - 32) / 1.8 // °F → °C
 				}
 			}
 		}

--- a/garden-app/server/water_schedule.go
+++ b/garden-app/server/water_schedule.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/calvinmclean/automated-garden/garden-app/pkg"
 	"github.com/calvinmclean/automated-garden/garden-app/pkg/notifications"
@@ -102,6 +104,9 @@ func NewWaterSchedulesAPI() *WaterSchedulesAPI {
 			return nil, babyapi.ErrInvalidRequest(fmt.Errorf("invalid component: %s", r.URL.Query().Get("type")))
 		}
 	}))
+
+	// Scaling example endpoint for previewing weather-based scaling
+	api.AddCustomRoute(http.MethodPost, "/scaling_example", babyapi.Handler(api.scalingExample))
 
 	api.ApplyExtension(extensions.HTMX[*pkg.WaterSchedule]{})
 
@@ -233,4 +238,176 @@ func (api *WaterSchedulesAPI) weatherClientExists(ctx context.Context, id xid.ID
 		return fmt.Errorf("error getting WeatherClient with ID %q: %w", id, err)
 	}
 	return nil
+}
+
+// scalingExample handles POST requests to preview how watering duration will scale based on weather configuration
+// nolint:gosec // Request body size is limited by babyapi middleware
+func (api *WaterSchedulesAPI) scalingExample(_ http.ResponseWriter, r *http.Request) render.Renderer {
+	// Parse form data from the request
+	if err := r.ParseForm(); err != nil {
+		return babyapi.ErrInvalidRequest(fmt.Errorf("error parsing form data: %w", err))
+	}
+
+	units := getUnitsFromRequest(r)
+	isImperial := units == "imperial"
+
+	// Parse base duration
+	baseDurationStr := r.FormValue("Duration")
+	var baseDuration time.Duration
+	if baseDurationStr != "" {
+		var err error
+		baseDuration, err = time.ParseDuration(baseDurationStr)
+		if err != nil {
+			// If standard parsing fails, the duration might be in a different format
+			// Just leave baseDuration as 0
+			baseDuration = 0
+		}
+	}
+
+	response := ScalingExampleResponse{
+		BaseDuration: baseDurationStr,
+	}
+
+	// Parse rain scaling configuration
+	rainInputMin := parseFormFloat(r, "WeatherControl.Rain.InputMin")
+	rainInputMax := parseFormFloat(r, "WeatherControl.Rain.InputMax")
+	rainFactorMin := parseFormFloat(r, "WeatherControl.Rain.FactorMin")
+	rainFactorMax := parseFormFloat(r, "WeatherControl.Rain.FactorMax")
+	rainInterpolation := r.FormValue("WeatherControl.Rain.Interpolation")
+
+	// If rain scaling is configured, generate examples
+	if rainInputMin != nil && rainInputMax != nil && rainFactorMin != nil && rainFactorMax != nil {
+		// Convert imperial to metric if needed (form values are in user units)
+		if isImperial {
+			*rainInputMin *= 25.4 // in → mm
+			*rainInputMax *= 25.4
+		}
+
+		scaler := &weather.WeatherScaler{
+			Interpolation: weather.InterpolationMode(rainInterpolation),
+			InputMin:      rainInputMin,
+			InputMax:      rainInputMax,
+			FactorMin:     rainFactorMin,
+			FactorMax:     rainFactorMax,
+		}
+
+		response.RainExamples = generateScalingExamples(scaler, baseDuration, isImperial, true)
+	}
+
+	// Parse temperature scaling configuration
+	tempInputMin := parseFormFloat(r, "WeatherControl.Temperature.InputMin")
+	tempInputMax := parseFormFloat(r, "WeatherControl.Temperature.InputMax")
+	tempFactorMin := parseFormFloat(r, "WeatherControl.Temperature.FactorMin")
+	tempFactorMax := parseFormFloat(r, "WeatherControl.Temperature.FactorMax")
+	tempInterpolation := r.FormValue("WeatherControl.Temperature.Interpolation")
+
+	// If temperature scaling is configured, generate examples
+	if tempInputMin != nil && tempInputMax != nil && tempFactorMin != nil && tempFactorMax != nil {
+		// Convert imperial to metric if needed (form values are in user units)
+		if isImperial {
+			*tempInputMin = (*tempInputMin - 32) / 1.8 // °F → °C
+			*tempInputMax = (*tempInputMax - 32) / 1.8
+		}
+
+		scaler := &weather.WeatherScaler{
+			Interpolation: weather.InterpolationMode(tempInterpolation),
+			InputMin:      tempInputMin,
+			InputMax:      tempInputMax,
+			FactorMin:     tempFactorMin,
+			FactorMax:     tempFactorMax,
+		}
+
+		response.TemperatureExamples = generateScalingExamples(scaler, baseDuration, isImperial, false)
+	}
+
+	return response
+}
+
+// parseFormFloat parses a float64 from form data
+func parseFormFloat(r *http.Request, name string) *float64 {
+	valueStr := r.FormValue(name)
+	if valueStr == "" {
+		return nil
+	}
+	value, err := strconv.ParseFloat(valueStr, 64)
+	if err != nil {
+		return nil
+	}
+	return &value
+}
+
+// generateScalingExamples creates 5 sample points across the input range
+func generateScalingExamples(scaler *weather.WeatherScaler, baseDuration time.Duration, isImperial bool, isRain bool) []ScalingExamplePoint {
+	if scaler.InputMin == nil || scaler.InputMax == nil {
+		return nil
+	}
+
+	inputMin := *scaler.InputMin
+	inputMax := *scaler.InputMax
+	inputRange := inputMax - inputMin
+
+	// Generate 5 sample points: min, 25%, 50%, 75%, max
+	percentages := []float64{0.0, 0.25, 0.5, 0.75, 1.0}
+	examples := make([]ScalingExamplePoint, len(percentages))
+
+	for i, pct := range percentages {
+		inputValue := inputMin + (inputRange * pct)
+		scaleFactor := scaler.Scale(inputValue)
+
+		// Convert to user units for display
+		displayValue := inputValue
+		unit := "mm"
+		if isRain {
+			if isImperial {
+				displayValue = inputValue / 25.4 // mm to inches
+				unit = "in"
+			}
+		} else {
+			if isImperial {
+				displayValue = inputValue*1.8 + 32 // Celsius to Fahrenheit
+				unit = "°F"
+			} else {
+				unit = "°C"
+			}
+		}
+
+		examples[i] = ScalingExamplePoint{
+			InputValue:  displayValue,
+			InputUnit:   unit,
+			ScaleFactor: scaleFactor,
+		}
+
+		// Calculate resulting duration if base duration is provided
+		if baseDuration > 0 {
+			resultDuration := time.Duration(float64(baseDuration) * scaleFactor)
+			examples[i].Duration = formatDurationShort(resultDuration)
+		}
+	}
+
+	return examples
+}
+
+// formatDurationShort formats a duration in a short, readable format
+func formatDurationShort(d time.Duration) string {
+	if d == 0 {
+		return "0s"
+	}
+
+	hours := int(d.Hours())
+	minutes := int(d.Minutes()) % 60
+	seconds := int(d.Seconds()) % 60
+
+	if hours > 0 {
+		if minutes > 0 {
+			return fmt.Sprintf("%dh%dm", hours, minutes)
+		}
+		return fmt.Sprintf("%dh", hours)
+	}
+	if minutes > 0 {
+		if seconds > 0 {
+			return fmt.Sprintf("%dm%ds", minutes, seconds)
+		}
+		return fmt.Sprintf("%dm", minutes)
+	}
+	return fmt.Sprintf("%ds", seconds)
 }

--- a/garden-app/server/water_schedule_responses.go
+++ b/garden-app/server/water_schedule_responses.go
@@ -120,3 +120,26 @@ func (aws AllWaterSchedulesResponse) HTML(_ http.ResponseWriter, r *http.Request
 
 	return waterSchedulesPageTemplate.Render(r, aws)
 }
+
+// ScalingExamplePoint represents a single sample point in the scaling preview
+type ScalingExamplePoint struct {
+	InputValue  float64 `json:"input_value"`
+	InputUnit   string  `json:"input_unit"`
+	ScaleFactor float64 `json:"scale_factor"`
+	Duration    string  `json:"duration,omitempty"`
+}
+
+// ScalingExampleResponse contains the scaling preview data for both rain and temperature
+type ScalingExampleResponse struct {
+	RainExamples        []ScalingExamplePoint `json:"rain_examples,omitempty"`
+	TemperatureExamples []ScalingExamplePoint `json:"temperature_examples,omitempty"`
+	BaseDuration        string                `json:"base_duration"`
+}
+
+func (ser ScalingExampleResponse) Render(w http.ResponseWriter, r *http.Request) error {
+	return nil
+}
+
+func (ser ScalingExampleResponse) HTML(_ http.ResponseWriter, r *http.Request) string {
+	return scalingExampleResultsTemplate.Render(r, ser)
+}

--- a/garden-app/server/water_schedule_test.go
+++ b/garden-app/server/water_schedule_test.go
@@ -27,6 +27,8 @@ import (
 
 var createdAt, _ = time.Parse(time.RFC3339Nano, "2021-10-03T11:24:52.891386-07:00")
 
+func float64Ptr(f float64) *float64 { return &f }
+
 func createExampleWaterSchedule() *pkg.WaterSchedule {
 	return &pkg.WaterSchedule{
 		ID:        babyapi.ID{ID: id},
@@ -62,21 +64,25 @@ func TestGetWaterSchedule(t *testing.T) {
 				StartTime: pkg.NewStartTime(createdAt),
 				StartDate: &createdAt,
 				WeatherControl: &weather.Control{
-					Rain: &weather.ScaleControl{
-						BaselineValue: float32Pointer(0),
-						Factor:        float32Pointer(0),
-						Range:         float32Pointer(25.4),
+					Rain: &weather.WeatherScaler{
 						ClientID:      weatherClientID,
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(0),
+						InputMax:      float64Ptr(30),
+						FactorMin:     float64Ptr(1.0),
+						FactorMax:     float64Ptr(0.0),
 					},
-					Temperature: &weather.ScaleControl{
-						BaselineValue: float32Pointer(30),
-						Factor:        float32Pointer(0.5),
-						Range:         float32Pointer(10),
+					Temperature: &weather.WeatherScaler{
 						ClientID:      weatherClientID,
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(20),
+						InputMax:      float64Ptr(40),
+						FactorMin:     float64Ptr(0.5),
+						FactorMax:     float64Ptr(1.5),
 					},
 				},
 			},
-			`{"id":"c5cvhpcbcv45e8bp16dg","duration":"1h0m0s","interval":"24h0m0s","start_date":"\d{4}-\d{2}-\d\dT\d\d:\d\d:\d\d(\.\d+)?(-07:00|Z)","start_time":"11:24:52-07:00","weather_control":{"rain_control":{"baseline_value":0,"factor":0,"range":25.4,"client_id":"c5cvhpcbcv45e8bp16dg"},"temperature_control":{"baseline_value":30,"factor":0.5,"range":10,"client_id":"c5cvhpcbcv45e8bp16dg"}},"weather_data":{"rain":{"mm":25.4,"inches":1.0000006},"temperature":{"celsius":80,"fahrenheit":176}},"next_water":{"time":"\d\d\d\d-\d\d-\d\dT11:24:52-07:00","duration":"0s"},"links":\[{"rel":"self","href":"/water_schedules/c5cvhpcbcv45e8bp16dg"}\]}`,
+			`{"id":"c5cvhpcbcv45e8bp16dg","duration":"1h0m0s","interval":"24h0m0s","start_date":"\d{4}-\d{2}-\d\dT\d\d:\d\d:\d\d(\.\d+)?(-07:00|Z)","start_time":"11:24:52-07:00","weather_control":{"rain_control":{"client_id":"c5cvhpcbcv45e8bp16dg","interpolation":"linear","input_min":0,"input_max":30,"factor_min":1,"factor_max":0},"temperature_control":{"client_id":"c5cvhpcbcv45e8bp16dg","interpolation":"linear","input_min":20,"input_max":40,"factor_min":0.5,"factor_max":1.5}},"weather_data":{"rain":{"mm":25.4,"inches":1.0000006},"temperature":{"celsius":80,"fahrenheit":176}},"next_water":{"time":"\d\d\d\d-\d\d-\d\dT11:24:52-07:00","duration":"13m48\.[0-9]+s"},"links":\[{"rel":"self","href":"/water_schedules/c5cvhpcbcv45e8bp16dg"}\]}`,
 		},
 		{
 			"SuccessfulWithRainAndTemperatureDataButWeatherDataExcluded",
@@ -88,21 +94,25 @@ func TestGetWaterSchedule(t *testing.T) {
 				StartTime: pkg.NewStartTime(createdAt),
 				StartDate: &createdAt,
 				WeatherControl: &weather.Control{
-					Rain: &weather.ScaleControl{
-						BaselineValue: float32Pointer(0),
-						Factor:        float32Pointer(0),
-						Range:         float32Pointer(25.4),
+					Rain: &weather.WeatherScaler{
 						ClientID:      weatherClientID,
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(0),
+						InputMax:      float64Ptr(25.4),
+						FactorMin:     float64Ptr(1.0),
+						FactorMax:     float64Ptr(1.0),
 					},
-					Temperature: &weather.ScaleControl{
-						BaselineValue: float32Pointer(30),
-						Factor:        float32Pointer(0.5),
-						Range:         float32Pointer(10),
+					Temperature: &weather.WeatherScaler{
 						ClientID:      weatherClientID,
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(20),
+						InputMax:      float64Ptr(40),
+						FactorMin:     float64Ptr(0.5),
+						FactorMax:     float64Ptr(1.5),
 					},
 				},
 			},
-			`{"id":"c5cvhpcbcv45e8bp16dg","duration":"1h0m0s","interval":"24h0m0s","start_date":"\d{4}-\d{2}-\d\dT\d\d:\d\d:\d\d(\.\d+)?(-07:00|Z)","start_time":"11:24:52-07:00","weather_control":{"rain_control":{"baseline_value":0,"factor":0,"range":25.4,"client_id":"c5cvhpcbcv45e8bp16dg"},"temperature_control":{"baseline_value":30,"factor":0.5,"range":10,"client_id":"c5cvhpcbcv45e8bp16dg"}},"next_water":{"time":"\d\d\d\d-\d\d-\d\dT11:24:52-07:00","duration":"1h0m0s"},"links":\[{"rel":"self","href":"/water_schedules/c5cvhpcbcv45e8bp16dg"}\]}`,
+			`{"id":"c5cvhpcbcv45e8bp16dg","duration":"1h0m0s","interval":"24h0m0s","start_date":"\d{4}-\d{2}-\d\dT\d\d:\d\d:\d\d(\.\d+)?(-07:00|Z)","start_time":"11:24:52-07:00","weather_control":{"rain_control":{"client_id":"c5cvhpcbcv45e8bp16dg","interpolation":"linear","input_min":0,"input_max":25.4,"factor_min":1,"factor_max":1},"temperature_control":{"client_id":"c5cvhpcbcv45e8bp16dg","interpolation":"linear","input_min":20,"input_max":40,"factor_min":0.5,"factor_max":1.5}},"next_water":{"time":"\d\d\d\d-\d\d-\d\dT11:24:52-07:00","duration":"1h0m0s"},"links":\[{"rel":"self","href":"/water_schedules/c5cvhpcbcv45e8bp16dg"}\]}`,
 		},
 		{
 			"ErrorRainWeatherClientDNE",
@@ -114,15 +124,17 @@ func TestGetWaterSchedule(t *testing.T) {
 				StartTime: pkg.NewStartTime(createdAt),
 				StartDate: &createdAt,
 				WeatherControl: &weather.Control{
-					Rain: &weather.ScaleControl{
-						BaselineValue: float32Pointer(0),
-						Factor:        float32Pointer(0),
-						Range:         float32Pointer(25.4),
+					Rain: &weather.WeatherScaler{
 						ClientID:      id2,
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(0),
+						InputMax:      float64Ptr(25.4),
+						FactorMin:     float64Ptr(1.0),
+						FactorMax:     float64Ptr(0.0),
 					},
 				},
 			},
-			`{"id":"c5cvhpcbcv45e8bp16dg","duration":"1h0m0s","interval":"24h0m0s","start_date":"\d{4}-\d{2}-\d\dT\d\d:\d\d:\d\d(\.\d+)?(-07:00|Z)","start_time":"11:24:52-07:00","weather_control":{"rain_control":{"baseline_value":0,"factor":0,"range":25.4,"client_id":"chkodpg3lcj13q82mq40"}},"weather_data":{},"next_water":{"time":"\d\d\d\d-\d\d-\d\dT11:24:52-07:00","duration":"59m59.99995904s","message":"error impacted duration scaling"},"links":\[{"rel":"self","href":"/water_schedules/c5cvhpcbcv45e8bp16dg"}\]}`,
+			`{"id":"c5cvhpcbcv45e8bp16dg","duration":"1h0m0s","interval":"24h0m0s","start_date":"\d{4}-\d{2}-\d\dT\d\d:\d\d:\d\d(\.\d+)?(-07:00|Z)","start_time":"11:24:52-07:00","weather_control":{"rain_control":{"client_id":"chkodpg3lcj13q82mq40","interpolation":"linear","input_min":0,"input_max":25.4,"factor_min":1,"factor_max":0}},"weather_data":{},"next_water":{"time":"\d\d\d\d-\d\d-\d\dT11:24:52-07:00","duration":"1h0m0s","message":"error impacted duration scaling"},"links":\[{"rel":"self","href":"/water_schedules/c5cvhpcbcv45e8bp16dg"}\]}`,
 		},
 		{
 			"ErrorTemperatureWeatherClientDNE",
@@ -134,15 +146,17 @@ func TestGetWaterSchedule(t *testing.T) {
 				StartTime: pkg.NewStartTime(createdAt),
 				StartDate: &createdAt,
 				WeatherControl: &weather.Control{
-					Temperature: &weather.ScaleControl{
-						BaselineValue: float32Pointer(30),
-						Factor:        float32Pointer(0.5),
-						Range:         float32Pointer(10),
+					Temperature: &weather.WeatherScaler{
 						ClientID:      id2,
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(20),
+						InputMax:      float64Ptr(40),
+						FactorMin:     float64Ptr(0.5),
+						FactorMax:     float64Ptr(1.5),
 					},
 				},
 			},
-			`{"id":"c5cvhpcbcv45e8bp16dg","duration":"1h0m0s","interval":"24h0m0s","start_date":"\d{4}-\d{2}-\d\dT\d\d:\d\d:\d\d(\.\d+)?(-07:00|Z)","start_time":"11:24:52-07:00","weather_control":{"temperature_control":{"baseline_value":30,"factor":0.5,"range":10,"client_id":"chkodpg3lcj13q82mq40"}},"weather_data":{},"next_water":{"time":"\d\d\d\d-\d\d-\d\dT11:24:52-07:00","duration":"59m59.99995904s","message":"error impacted duration scaling"},"links":\[{"rel":"self","href":"/water_schedules/c5cvhpcbcv45e8bp16dg"}\]}`,
+			`{"id":"c5cvhpcbcv45e8bp16dg","duration":"1h0m0s","interval":"24h0m0s","start_date":"\d{4}-\d{2}-\d\dT\d\d:\d\d:\d\d(\.\d+)?(-07:00|Z)","start_time":"11:24:52-07:00","weather_control":{"temperature_control":{"client_id":"chkodpg3lcj13q82mq40","interpolation":"linear","input_min":20,"input_max":40,"factor_min":[0-9.]+,"factor_max":[0-9.]+}},"weather_data":{},"next_water":{"time":"\d\d\d\d-\d\d-\d\dT11:24:52-07:00","duration":"[0-9a-zµs.]+","message":"error impacted duration scaling"},"links":\[{"rel":"self","href":"/water_schedules/c5cvhpcbcv45e8bp16dg"}\]}`,
 		},
 	}
 
@@ -236,13 +250,13 @@ func TestUpdateWaterSchedule(t *testing.T) {
 		},
 		{
 			"BadRequestInvalidTemperatureControl",
-			`{"weather_control":{"temperature_control":{"baseline_value":27,"factor":-1,"range":10,"client_id":"c5cvhpcbcv45e8bp16dg"}}}`,
-			`{"status":"Invalid request.","error":"invalid WaterSchedule.WeatherControl after patching: error validating temperature_control: factor must be between 0 and 1"}`,
+			`{"weather_control":{"temperature_control":{"client_id":"c5cvhpcbcv45e8bp16dg","interpolation":"linear","input_min":20,"input_max":40,"factor_min":-1,"factor_max":1.5}}}`,
+			`{"status":"Invalid request.","error":"invalid WaterSchedule.WeatherControl after patching: error validating temperature_control: factors must be non-negative"}`,
 			http.StatusBadRequest,
 		},
 		{
 			"ErrorRainWeatherClientDNE",
-			`{"weather_control":{"rain_control":{"baseline_value":0,"factor":0,"range":25.4,"client_id":"chkodpg3lcj13q82mq40"}}}`,
+			`{"weather_control":{"rain_control":{"client_id":"chkodpg3lcj13q82mq40","interpolation":"linear","input_min":0,"input_max":25.4,"factor_min":0,"factor_max":0}}}`,
 			`{"status":"Invalid request.","error":"unable to get WeatherClients for WaterSchedule: error getting client for RainControl: error getting WeatherClient with ID \\"chkodpg3lcj13q82mq40\\": resource not found"}`,
 			http.StatusBadRequest,
 		},
@@ -447,13 +461,13 @@ func TestCreateWaterSchedule(t *testing.T) {
 		},
 		{
 			"ErrorRainWeatherClientDNE",
-			`{"duration":"1s","interval":"24h0m0s","start_time":"11:24:52-07:00", "weather_control":{"rain_control":{"baseline_value":0,"factor":0,"range":25.4,"client_id":"c5cvhpcbcv45e8bp16dg"}}}`,
+			`{"duration":"1s","interval":"24h0m0s","start_time":"11:24:52-07:00", "weather_control":{"rain_control":{"client_id":"c5cvhpcbcv45e8bp16dg","interpolation":"linear","input_min":0,"input_max":25.4,"factor_min":0,"factor_max":0}}}`,
 			`{"status":"Invalid request.","error":"unable to get WeatherClients for WaterSchedule: error getting client for RainControl: error getting WeatherClient with ID \\"c5cvhpcbcv45e8bp16dg\\": resource not found"}`,
 			http.StatusBadRequest,
 		},
 		{
 			"ErrorTemperatureWeatherClientDNE",
-			`{"duration":"1s","interval":"24h0m0s","start_time":"11:24:52-07:00", "weather_control":{"temperature_control":{"baseline_value":0,"factor":0,"range":25.4,"client_id":"c5cvhpcbcv45e8bp16dg"}}}`,
+			`{"duration":"1s","interval":"24h0m0s","start_time":"11:24:52-07:00", "weather_control":{"temperature_control":{"client_id":"c5cvhpcbcv45e8bp16dg","interpolation":"linear","input_min":0,"input_max":25.4,"factor_min":0,"factor_max":0}}}`,
 			`{"status":"Invalid request.","error":"unable to get WeatherClients for WaterSchedule: error getting client for TemperatureControl: error getting WeatherClient with ID \\"c5cvhpcbcv45e8bp16dg\\": resource not found"}`,
 			http.StatusBadRequest,
 		},
@@ -529,13 +543,13 @@ func TestUpdateWaterSchedulePUT(t *testing.T) {
 		},
 		{
 			"ErrorRainWeatherClientDNE",
-			`{"id":"c5cvhpcbcv45e8bp16dg","duration":"1s","interval":"24h0m0s","start_time":"11:24:52-07:00", "weather_control":{"rain_control":{"baseline_value":0,"factor":0,"range":25.4,"client_id":"c5cvhpcbcv45e8bp16dg"}}}`,
+			`{"id":"c5cvhpcbcv45e8bp16dg","duration":"1s","interval":"24h0m0s","start_time":"11:24:52-07:00", "weather_control":{"rain_control":{"client_id":"c5cvhpcbcv45e8bp16dg","interpolation":"linear","input_min":0,"input_max":25.4,"factor_min":0,"factor_max":0}}}`,
 			`{"status":"Invalid request.","error":"unable to get WeatherClients for WaterSchedule: error getting client for RainControl: error getting WeatherClient with ID \\"c5cvhpcbcv45e8bp16dg\\": resource not found"}`,
 			http.StatusBadRequest,
 		},
 		{
 			"ErrorTemperatureWeatherClientDNE",
-			`{"id":"c5cvhpcbcv45e8bp16dg","duration":"1s","interval":"24h0m0s","start_time":"11:24:52-07:00", "weather_control":{"temperature_control":{"baseline_value":0,"factor":0,"range":25.4,"client_id":"c5cvhpcbcv45e8bp16dg"}}}`,
+			`{"id":"c5cvhpcbcv45e8bp16dg","duration":"1s","interval":"24h0m0s","start_time":"11:24:52-07:00", "weather_control":{"temperature_control":{"client_id":"c5cvhpcbcv45e8bp16dg","interpolation":"linear","input_min":0,"input_max":25.4,"factor_min":0,"factor_max":0}}}`,
 			`{"status":"Invalid request.","error":"unable to get WeatherClients for WaterSchedule: error getting client for TemperatureControl: error getting WeatherClient with ID \\"c5cvhpcbcv45e8bp16dg\\": resource not found"}`,
 			http.StatusBadRequest,
 		},
@@ -611,129 +625,151 @@ func TestWaterScheduleRequest(t *testing.T) {
 			"missing required start_time field",
 		},
 		{
-			"EmptyWeatherControlBaselineTemperature",
-			&pkg.WaterSchedule{
-				Interval:  &pkg.Duration{Duration: time.Hour * 24},
-				Duration:  &pkg.Duration{Duration: time.Second},
-				StartTime: pkg.NewStartTime(now),
-				WeatherControl: &weather.Control{
-					Temperature: &weather.ScaleControl{
-						Factor: float32Pointer(0.5),
-						Range:  float32Pointer(10),
-					},
-				},
-			},
-			"error validating weather_control: error validating temperature_control: missing required field: baseline_value",
-		},
-		{
-			"EmptyWeatherControlFactor",
-			&pkg.WaterSchedule{
-				Interval:  &pkg.Duration{Duration: time.Hour * 24},
-				Duration:  &pkg.Duration{Duration: time.Second},
-				StartTime: pkg.NewStartTime(now),
-				WeatherControl: &weather.Control{
-					Temperature: &weather.ScaleControl{
-						BaselineValue: float32Pointer(27),
-						Range:         float32Pointer(10),
-					},
-				},
-			},
-			"error validating weather_control: error validating temperature_control: missing required field: factor",
-		},
-		{
-			"EmptyWeatherControlRange",
-			&pkg.WaterSchedule{
-				Interval:  &pkg.Duration{Duration: time.Hour * 24},
-				Duration:  &pkg.Duration{Duration: time.Second},
-				StartTime: pkg.NewStartTime(now),
-				WeatherControl: &weather.Control{
-					Temperature: &weather.ScaleControl{
-						BaselineValue: float32Pointer(27),
-						Factor:        float32Pointer(0.5),
-					},
-				},
-			},
-			"error validating weather_control: error validating temperature_control: missing required field: range",
-		},
-		{
 			"EmptyWeatherControlClientID",
 			&pkg.WaterSchedule{
 				Interval:  &pkg.Duration{Duration: time.Hour * 24},
 				Duration:  &pkg.Duration{Duration: time.Second},
 				StartTime: pkg.NewStartTime(now),
 				WeatherControl: &weather.Control{
-					Temperature: &weather.ScaleControl{
-						BaselineValue: float32Pointer(27),
-						Factor:        float32Pointer(0.5),
-						Range:         float32Pointer(10),
+					Temperature: &weather.WeatherScaler{
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(20),
+						InputMax:      float64Ptr(40),
+						FactorMin:     float64Ptr(0.5),
+						FactorMax:     float64Ptr(1.5),
 					},
 				},
 			},
 			"error validating weather_control: error validating temperature_control: missing required field: client_id",
 		},
 		{
-			"WeatherControlInvalidFactorBig",
+			"EmptyWeatherControlInputMin",
 			&pkg.WaterSchedule{
 				Interval:  &pkg.Duration{Duration: time.Hour * 24},
 				Duration:  &pkg.Duration{Duration: time.Second},
 				StartTime: pkg.NewStartTime(now),
 				WeatherControl: &weather.Control{
-					Temperature: &weather.ScaleControl{
-						BaselineValue: float32Pointer(27),
-						Factor:        float32Pointer(2),
-						Range:         float32Pointer(10),
+					Temperature: &weather.WeatherScaler{
+						ClientID:      xid.New(),
+						Interpolation: weather.Linear,
+						InputMax:      float64Ptr(40),
+						FactorMin:     float64Ptr(0.5),
+						FactorMax:     float64Ptr(1.5),
 					},
 				},
 			},
-			"error validating weather_control: error validating temperature_control: factor must be between 0 and 1",
+			"error validating weather_control: error validating temperature_control: missing required field: input_min",
 		},
 		{
-			"WeatherControlInvalidFactorSmall",
+			"EmptyWeatherControlInputMax",
 			&pkg.WaterSchedule{
 				Interval:  &pkg.Duration{Duration: time.Hour * 24},
 				Duration:  &pkg.Duration{Duration: time.Second},
 				StartTime: pkg.NewStartTime(now),
 				WeatherControl: &weather.Control{
-					Temperature: &weather.ScaleControl{
-						BaselineValue: float32Pointer(27),
-						Factor:        float32Pointer(-1),
-						Range:         float32Pointer(10),
+					Temperature: &weather.WeatherScaler{
+						ClientID:      xid.New(),
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(20),
+						FactorMin:     float64Ptr(0.5),
+						FactorMax:     float64Ptr(1.5),
 					},
 				},
 			},
-			"error validating weather_control: error validating temperature_control: factor must be between 0 and 1",
+			"error validating weather_control: error validating temperature_control: missing required field: input_max",
 		},
 		{
-			"WeatherControlInvalidRange",
+			"EmptyWeatherControlFactorMin",
 			&pkg.WaterSchedule{
 				Interval:  &pkg.Duration{Duration: time.Hour * 24},
 				Duration:  &pkg.Duration{Duration: time.Second},
 				StartTime: pkg.NewStartTime(now),
 				WeatherControl: &weather.Control{
-					Temperature: &weather.ScaleControl{
-						BaselineValue: float32Pointer(27),
-						Factor:        float32Pointer(0.5),
-						Range:         float32Pointer(-1),
+					Temperature: &weather.WeatherScaler{
+						ClientID:      xid.New(),
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(20),
+						InputMax:      float64Ptr(40),
+						FactorMax:     float64Ptr(1.5),
 					},
 				},
 			},
-			"error validating weather_control: error validating temperature_control: range must be a positive number",
+			"error validating weather_control: error validating temperature_control: missing required field: factor_min",
 		},
 		{
-			"WeatherControlRainInvalidRange",
+			"EmptyWeatherControlFactorMax",
 			&pkg.WaterSchedule{
 				Interval:  &pkg.Duration{Duration: time.Hour * 24},
 				Duration:  &pkg.Duration{Duration: time.Second},
 				StartTime: pkg.NewStartTime(now),
 				WeatherControl: &weather.Control{
-					Rain: &weather.ScaleControl{
-						BaselineValue: float32Pointer(27),
-						Factor:        float32Pointer(0.5),
-						Range:         float32Pointer(-1),
+					Temperature: &weather.WeatherScaler{
+						ClientID:      xid.New(),
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(20),
+						InputMax:      float64Ptr(40),
+						FactorMin:     float64Ptr(0.5),
 					},
 				},
 			},
-			"error validating weather_control: error validating rain_control: range must be a positive number",
+			"error validating weather_control: error validating temperature_control: missing required field: factor_max",
+		},
+		{
+			"WeatherControlInvalidFactorMin",
+			&pkg.WaterSchedule{
+				Interval:  &pkg.Duration{Duration: time.Hour * 24},
+				Duration:  &pkg.Duration{Duration: time.Second},
+				StartTime: pkg.NewStartTime(now),
+				WeatherControl: &weather.Control{
+					Temperature: &weather.WeatherScaler{
+						ClientID:      xid.New(),
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(20),
+						InputMax:      float64Ptr(40),
+						FactorMin:     float64Ptr(-1),
+						FactorMax:     float64Ptr(1.5),
+					},
+				},
+			},
+			"error validating weather_control: error validating temperature_control: factors must be non-negative",
+		},
+		{
+			"WeatherControlInvalidInputRange",
+			&pkg.WaterSchedule{
+				Interval:  &pkg.Duration{Duration: time.Hour * 24},
+				Duration:  &pkg.Duration{Duration: time.Second},
+				StartTime: pkg.NewStartTime(now),
+				WeatherControl: &weather.Control{
+					Temperature: &weather.WeatherScaler{
+						ClientID:      xid.New(),
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(40),
+						InputMax:      float64Ptr(20),
+						FactorMin:     float64Ptr(0.5),
+						FactorMax:     float64Ptr(1.5),
+					},
+				},
+			},
+			"error validating weather_control: error validating temperature_control: input_max must be greater than input_min",
+		},
+		{
+			"WeatherControlRainInvalidInputRange",
+			&pkg.WaterSchedule{
+				Interval:  &pkg.Duration{Duration: time.Hour * 24},
+				Duration:  &pkg.Duration{Duration: time.Second},
+				StartTime: pkg.NewStartTime(now),
+				WeatherControl: &weather.Control{
+					Rain: &weather.WeatherScaler{
+						ClientID:      xid.New(),
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(50),
+						InputMax:      float64Ptr(20),
+						FactorMin:     float64Ptr(0.5),
+						FactorMax:     float64Ptr(1.0),
+					},
+				},
+			},
+			"error validating weather_control: error validating rain_control: input_max must be greater than input_min",
 		},
 		{
 			"ActivePeriodInvalid",
@@ -755,11 +791,13 @@ func TestWaterScheduleRequest(t *testing.T) {
 			Interval:  &pkg.Duration{Duration: time.Hour * 24},
 			StartTime: pkg.NewStartTime(now),
 			WeatherControl: &weather.Control{
-				Temperature: &weather.ScaleControl{
-					BaselineValue: float32Pointer(27),
-					Factor:        float32Pointer(0.5),
-					Range:         float32Pointer(10),
+				Temperature: &weather.WeatherScaler{
 					ClientID:      xid.New(),
+					Interpolation: weather.Linear,
+					InputMin:      float64Ptr(20),
+					InputMax:      float64Ptr(40),
+					FactorMin:     float64Ptr(0.5),
+					FactorMax:     float64Ptr(1.5),
 				},
 			},
 		}

--- a/garden-app/server/water_schedule_test.go
+++ b/garden-app/server/water_schedule_test.go
@@ -156,7 +156,7 @@ func TestGetWaterSchedule(t *testing.T) {
 					},
 				},
 			},
-			`{"id":"c5cvhpcbcv45e8bp16dg","duration":"1h0m0s","interval":"24h0m0s","start_date":"\d{4}-\d{2}-\d\dT\d\d:\d\d:\d\d(\.\d+)?(-07:00|Z)","start_time":"11:24:52-07:00","weather_control":{"temperature_control":{"client_id":"chkodpg3lcj13q82mq40","interpolation":"linear","input_min":20,"input_max":40,"factor_min":[0-9.]+,"factor_max":[0-9.]+}},"weather_data":{},"next_water":{"time":"\d\d\d\d-\d\d-\d\dT11:24:52-07:00","duration":"[0-9a-zµs.]+","message":"error impacted duration scaling"},"links":\[{"rel":"self","href":"/water_schedules/c5cvhpcbcv45e8bp16dg"}\]}`,
+			`{"id":"c5cvhpcbcv45e8bp16dg","duration":"1h0m0s","interval":"24h0m0s","start_date":"\d{4}-\d{2}-\d\dT\d\d:\d\d:\d\d(\.\d+)?(-07:00|Z)","start_time":"11:24:52-07:00","weather_control":{"temperature_control":{"client_id":"chkodpg3lcj13q82mq40","interpolation":"linear","input_min":20,"input_max":40,"factor_min":0\.5,"factor_max":1\.5}},"weather_data":{},"next_water":{"time":"\d\d\d\d-\d\d-\d\dT11:24:52-07:00","duration":"[0-9a-zµs.]+","message":"error impacted duration scaling"},"links":\[{"rel":"self","href":"/water_schedules/c5cvhpcbcv45e8bp16dg"}\]}`,
 		},
 	}
 

--- a/garden-app/server/weather_clients_test.go
+++ b/garden-app/server/weather_clients_test.go
@@ -146,11 +146,21 @@ func TestDeleteWeatherClient(t *testing.T) {
 
 	ws1 := createExampleWaterSchedule()
 	ws1.WeatherControl = &weather.Control{
-		Rain: &weather.ScaleControl{
-			ClientID: id2,
+		Rain: &weather.WeatherScaler{
+			ClientID:      id2,
+			Interpolation: weather.Linear,
+			InputMin:      float64Ptr(0),
+			InputMax:      float64Ptr(25.4),
+			FactorMin:     float64Ptr(0.5),
+			FactorMax:     float64Ptr(1.0),
 		},
-		Temperature: &weather.ScaleControl{
-			ClientID: id2,
+		Temperature: &weather.WeatherScaler{
+			ClientID:      id2,
+			Interpolation: weather.Linear,
+			InputMin:      float64Ptr(20),
+			InputMax:      float64Ptr(40),
+			FactorMin:     float64Ptr(0.5),
+			FactorMax:     float64Ptr(1.5),
 		},
 	}
 
@@ -158,11 +168,21 @@ func TestDeleteWeatherClient(t *testing.T) {
 	ws2 := createExampleWaterSchedule()
 	ws2.ID = babyapi.NewID()
 	ws2.WeatherControl = &weather.Control{
-		Rain: &weather.ScaleControl{
-			ClientID: xid.New(),
+		Rain: &weather.WeatherScaler{
+			ClientID:      xid.New(),
+			Interpolation: weather.Linear,
+			InputMin:      float64Ptr(0),
+			InputMax:      float64Ptr(25.4),
+			FactorMin:     float64Ptr(0.5),
+			FactorMax:     float64Ptr(1.0),
 		},
-		Temperature: &weather.ScaleControl{
-			ClientID: xid.New(),
+		Temperature: &weather.WeatherScaler{
+			ClientID:      xid.New(),
+			Interpolation: weather.Linear,
+			InputMin:      float64Ptr(20),
+			InputMax:      float64Ptr(40),
+			FactorMin:     float64Ptr(0.5),
+			FactorMax:     float64Ptr(1.5),
 		},
 	}
 

--- a/garden-app/server/zone_test.go
+++ b/garden-app/server/zone_test.go
@@ -102,11 +102,6 @@ func setupZoneAndGardenStorage(t *testing.T) *storage.Client {
 	return storageClient
 }
 
-func float32Pointer(n float64) *float32 {
-	f := float32(n)
-	return &f
-}
-
 func pointer[T any](v T) *T {
 	return &v
 }
@@ -137,24 +132,28 @@ func TestGetZone(t *testing.T) {
 				Duration:  &pkg.Duration{Duration: time.Hour},
 				StartTime: pkg.NewStartTime(createdAt),
 				WeatherControl: &weather.Control{
-					Rain: &weather.ScaleControl{
-						BaselineValue: float32Pointer(0),
-						Factor:        float32Pointer(0),
-						Range:         float32Pointer(25.4),
+					Rain: &weather.WeatherScaler{
 						ClientID:      weatherClientID,
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(0),
+						InputMax:      float64Ptr(25.5),
+						FactorMin:     float64Ptr(1.0),
+						FactorMax:     float64Ptr(0.0),
 					},
-					Temperature: &weather.ScaleControl{
-						BaselineValue: float32Pointer(30),
-						Factor:        float32Pointer(0.5),
-						Range:         float32Pointer(10),
+					Temperature: &weather.WeatherScaler{
 						ClientID:      weatherClientID,
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(20),
+						InputMax:      float64Ptr(40),
+						FactorMin:     float64Ptr(0.5),
+						FactorMax:     float64Ptr(1.5),
 					},
 				},
 			}},
 			func(influxdbClient *influxdb.MockClient) {
 				influxdbClient.On("Close")
 			},
-			`{"name":"test-zone","id":"c5cvhpcbcv45e8bp16dg","garden_id":"c5cvhpcbcv45e8bp16dg","position":0,"created_at":"2021-10-03T11:24:52-07:00","water_schedule_ids":\["c5cvhpcbcv45e8bp16dg"\],"skip_count":null,"weather_data":{"rain":{"mm":25.4,"inches":1.0000006},"temperature":{"celsius":80,"fahrenheit":176}},"next_water":{"time":"\d\d\d\d-\d\d-\d\dT11:24:52-07:00","duration":"0s","water_schedule_id":"c5cvhpcbcv45e8bp16dg"},"links":\[{"rel":"self","href":"/gardens/c5cvhpcbcv45e8bp16dg/zones/c5cvhpcbcv45e8bp16dg"},{"rel":"garden","href":"/gardens/c5cvhpcbcv45e8bp16dg"},{"rel":"action","href":"/gardens/c5cvhpcbcv45e8bp16dg/zones/c5cvhpcbcv45e8bp16dg/action"},{"rel":"history","href":"/gardens/c5cvhpcbcv45e8bp16dg/zones/c5cvhpcbcv45e8bp16dg/history"}\]}`,
+			`{"name":"test-zone","id":"c5cvhpcbcv45e8bp16dg","garden_id":"c5cvhpcbcv45e8bp16dg","position":0,"created_at":"2021-10-03T11:24:52-07:00","water_schedule_ids":\["c5cvhpcbcv45e8bp16dg"\],"skip_count":null,"weather_data":{"rain":{"mm":25.4,"inches":1.0000006},"temperature":{"celsius":80,"fahrenheit":176}},"next_water":{"time":"\d\d\d\d-\d\d-\d\dT11:24:52-07:00","duration":"21.17655137s","water_schedule_id":"c5cvhpcbcv45e8bp16dg"},"links":\[{"rel":"self","href":"/gardens/c5cvhpcbcv45e8bp16dg/zones/c5cvhpcbcv45e8bp16dg"},{"rel":"garden","href":"/gardens/c5cvhpcbcv45e8bp16dg"},{"rel":"action","href":"/gardens/c5cvhpcbcv45e8bp16dg/zones/c5cvhpcbcv45e8bp16dg/action"},{"rel":"history","href":"/gardens/c5cvhpcbcv45e8bp16dg/zones/c5cvhpcbcv45e8bp16dg/history"}\]}`,
 		},
 		{
 			"SuccessfulWithRainAndTemperatureDataButWeatherDataExcluded",
@@ -165,17 +164,21 @@ func TestGetZone(t *testing.T) {
 				Duration:  &pkg.Duration{Duration: time.Hour},
 				StartTime: pkg.NewStartTime(createdAt),
 				WeatherControl: &weather.Control{
-					Rain: &weather.ScaleControl{
-						BaselineValue: float32Pointer(0),
-						Factor:        float32Pointer(0),
-						Range:         float32Pointer(25.4),
+					Rain: &weather.WeatherScaler{
 						ClientID:      weatherClientID,
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(0),
+						InputMax:      float64Ptr(25.5),
+						FactorMin:     float64Ptr(1.0),
+						FactorMax:     float64Ptr(0.0),
 					},
-					Temperature: &weather.ScaleControl{
-						BaselineValue: float32Pointer(30),
-						Factor:        float32Pointer(0.5),
-						Range:         float32Pointer(10),
+					Temperature: &weather.WeatherScaler{
 						ClientID:      weatherClientID,
+						Interpolation: weather.Linear,
+						InputMin:      float64Ptr(20),
+						InputMax:      float64Ptr(40),
+						FactorMin:     float64Ptr(0.5),
+						FactorMax:     float64Ptr(1.5),
 					},
 				},
 			}},

--- a/garden-app/worker/water_schedule_actions.go
+++ b/garden-app/worker/water_schedule_actions.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/calvinmclean/automated-garden/garden-app/pkg"
 	"github.com/calvinmclean/automated-garden/garden-app/pkg/action"
-	"github.com/rs/xid"
 )
 
 // ExecuteScheduledWaterAction will run ExecuteWaterAction after checking SkipCount and scaling based on weather data
@@ -79,7 +78,7 @@ func (w *Worker) ScaleWateringDuration(ws *pkg.WaterSchedule) (time.Duration, bo
 	}
 
 	if ws.HasRainControl() {
-		weatherClient, err := w.storageClient.GetWeatherClient(xid.ID(ws.WeatherControl.Rain.ClientID))
+		weatherClient, err := w.storageClient.GetWeatherClient(ws.WeatherControl.Rain.ClientID)
 		if err != nil {
 			hadError = true
 			w.logger.Warn("error getting WeatherClient for RainControl", "error", err)

--- a/garden-app/worker/water_schedule_actions.go
+++ b/garden-app/worker/water_schedule_actions.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/calvinmclean/automated-garden/garden-app/pkg"
 	"github.com/calvinmclean/automated-garden/garden-app/pkg/action"
+	"github.com/rs/xid"
 )
 
 // ExecuteScheduledWaterAction will run ExecuteWaterAction after checking SkipCount and scaling based on weather data
@@ -53,7 +54,7 @@ func (w *Worker) exerciseWeatherControl(ws *pkg.WaterSchedule) (time.Duration, e
 // ScaleWateringDuration returns a new watering duration based on weather scaling. It will not return
 // any errors if they are encountered because there are multiple factors impacting watering
 func (w *Worker) ScaleWateringDuration(ws *pkg.WaterSchedule) (time.Duration, bool) {
-	scaleFactor := float32(1)
+	scaleFactor := 1.0
 	hadError := false
 
 	if ws.HasTemperatureControl() {
@@ -67,7 +68,7 @@ func (w *Worker) ScaleWateringDuration(ws *pkg.WaterSchedule) (time.Duration, bo
 				hadError = true
 				w.logger.Warn("error getting average high temperatures", "error", err)
 			} else {
-				scaleFactor = ws.WeatherControl.Temperature.Scale(avgHighTemp)
+				scaleFactor = ws.WeatherControl.Temperature.Scale(float64(avgHighTemp))
 				w.logger.With(
 					"avg_high_temp", avgHighTemp,
 					"time_period", ws.Interval.String(),
@@ -78,7 +79,7 @@ func (w *Worker) ScaleWateringDuration(ws *pkg.WaterSchedule) (time.Duration, bo
 	}
 
 	if ws.HasRainControl() {
-		weatherClient, err := w.storageClient.GetWeatherClient(ws.WeatherControl.Rain.ClientID)
+		weatherClient, err := w.storageClient.GetWeatherClient(xid.ID(ws.WeatherControl.Rain.ClientID))
 		if err != nil {
 			hadError = true
 			w.logger.Warn("error getting WeatherClient for RainControl", "error", err)
@@ -88,7 +89,7 @@ func (w *Worker) ScaleWateringDuration(ws *pkg.WaterSchedule) (time.Duration, bo
 				hadError = true
 				w.logger.Warn("error getting rain data", "error", err)
 			} else {
-				rainScaleFactor := ws.WeatherControl.Rain.InvertedScaleDownOnly(totalRain)
+				rainScaleFactor := ws.WeatherControl.Rain.Scale(float64(totalRain))
 				w.logger.With(
 					"total_rain", totalRain,
 					"time_period", ws.Interval.String(),
@@ -101,5 +102,9 @@ func (w *Worker) ScaleWateringDuration(ws *pkg.WaterSchedule) (time.Duration, bo
 
 	w.logger.Info("compounded scale factor", "compound_scale_factor", scaleFactor)
 
-	return time.Duration(float32(ws.Duration.Duration) * scaleFactor), hadError
+	result := time.Duration(float64(ws.Duration.Duration) * scaleFactor)
+	if result.Milliseconds() == 0 {
+		return 0, hadError
+	}
+	return result, hadError
 }

--- a/garden-app/worker/water_schedule_actions_test.go
+++ b/garden-app/worker/water_schedule_actions_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+func float64Ptr(f float64) *float64 { return &f }
+
 func TestExecuteScheduledWaterAction(t *testing.T) {
 	CreateNewID = func() xid.ID { return xid.NilID() }
 	defer func() { CreateNewID = xid.New }()
@@ -27,17 +29,21 @@ func TestExecuteScheduledWaterAction(t *testing.T) {
 		TopicPrefix: "garden",
 	}
 	weatherClientID, _ := xid.FromString("c5cvhpcbcv45e8bp16dg")
-	temperatureControl := &weather.ScaleControl{
-		BaselineValue: float32Pointer(70),
-		Factor:        float32Pointer(0.5),
-		Range:         float32Pointer(30),
+	temperatureControl := &weather.WeatherScaler{
 		ClientID:      weatherClientID,
+		Interpolation: weather.Linear,
+		InputMin:      float64Ptr(40),
+		InputMax:      float64Ptr(100),
+		FactorMin:     float64Ptr(0.5),
+		FactorMax:     float64Ptr(1.5),
 	}
-	rainControl := &weather.ScaleControl{
-		BaselineValue: float32Pointer(0),
-		Factor:        float32Pointer(0),
-		Range:         float32Pointer(50),
+	rainControl := &weather.WeatherScaler{
 		ClientID:      weatherClientID,
+		Interpolation: weather.Linear,
+		InputMin:      float64Ptr(0),
+		InputMax:      float64Ptr(50),
+		FactorMin:     float64Ptr(1.0),
+		FactorMax:     float64Ptr(0.0),
 	}
 
 	tests := []struct {

--- a/garden-app/worker/zone_action_test.go
+++ b/garden-app/worker/zone_action_test.go
@@ -126,8 +126,3 @@ func uintPointer(n uint) *uint {
 	uintn := uint(n)
 	return &uintn
 }
-
-func float32Pointer(n float64) *float32 {
-	f := float32(n)
-	return &f
-}


### PR DESCRIPTION
## Description

Resolves #90 

Add a new `WeatherScaler` with separate input Min/Max and factor Min/Max. Also introduce Interpolators for different types of scaling (linear, step, etc.).

- Input Min/Max: corresponds to factor min/max and is easier to understand than using a "range" like the old setup
- Factor Min/Max: more clear than just a single factor, more flexible for different configurations, and makes scaling down more clear (previously, the rain scaling was just implied to scale down)