### PR TITLE
fix(fan): align fan scheduler StartAt with NextChange cycle grid

### DIFF
--- a/garden-app/pkg/fan_schedule.go
+++ b/garden-app/pkg/fan_schedule.go
@@ -65,6 +65,7 @@ func (fs FanSchedule) NextChange(now time.Time) (time.Time, bool) {
 		return time.Time{}, false
 	}
 
+	now = now.UTC()
 	anchor := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 
 	// If anchor is in the future, the first cycle hasn't started yet

--- a/garden-app/pkg/fan_schedule_test.go
+++ b/garden-app/pkg/fan_schedule_test.go
@@ -191,3 +191,57 @@ func TestFanScheduleNextChange(t *testing.T) {
 		})
 	}
 }
+
+func TestFanScheduleNextChange_Timezone(t *testing.T) {
+	// Use a timezone east of UTC where the naive local-date-at-UTC anchor would be
+	// in the future and produce incorrect results.
+	loc := time.FixedZone("UTC+8", 8*60*60)
+	duration := &Duration{Duration: 30 * time.Minute}
+	interval := &Duration{Duration: 2 * time.Hour}
+
+	tests := []struct {
+		name             string
+		now              time.Time
+		expectedAfter    time.Duration
+		expectedActive   bool
+		expectedIsActive bool
+	}{
+		{
+			"EarlyMorningBeforeUTCMidnight",
+			// 2024-01-01 06:00 UTC+8 = 2023-12-31 22:00 UTC.
+			// The cycle is anchored at UTC midnight, so the next ON is 30m away.
+			time.Date(2024, 1, 1, 6, 0, 0, 0, loc),
+			30 * time.Minute,
+			true,
+			false,
+		},
+		{
+			"DuringOffPeriodNearMidnight",
+			// 2024-01-01 00:15 UTC+8 = 2023-12-31 16:15 UTC.
+			// The ON period started at 2023-12-31 23:00 UTC+8 and ends at 01:30 UTC+8.
+			time.Date(2024, 1, 1, 0, 15, 0, 0, loc),
+			1*time.Hour + 15*time.Minute,
+			true,
+			false,
+		},
+		{
+			"DuringActivePeriod",
+			// 2024-01-01 10:45 UTC+8 = 2024-01-01 02:45 UTC.
+			// This is 15m into a 30m ON period.
+			time.Date(2024, 1, 1, 10, 45, 0, 0, loc),
+			15 * time.Minute,
+			false,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schedule := &FanSchedule{Duration: duration, Interval: interval}
+			nextChange, willBeActive := schedule.NextChange(tt.now)
+			assert.WithinDuration(t, tt.now.Add(tt.expectedAfter), nextChange, time.Second)
+			assert.Equal(t, tt.expectedActive, willBeActive)
+			assert.Equal(t, tt.expectedIsActive, schedule.IsActiveAtTime(tt.now))
+		})
+	}
+}

--- a/garden-app/worker/scheduler.go
+++ b/garden-app/worker/scheduler.go
@@ -343,8 +343,18 @@ func (w *Worker) ScheduleFanActions(g *pkg.Garden) error {
 	logger := w.contextLogger(g, nil, nil)
 	logger.Info("creating scheduled Job for fan Garden", "fan_schedule", *g.FanSchedule)
 
-	startDate := clock.Now().AddDate(0, 0, -1)
-	startTime := time.Date(startDate.Year(), startDate.Month(), startDate.Day(), 0, 0, 0, 0, time.UTC)
+	// Use NextChange to determine correct StartAt for the fan job.
+	// This ensures the scheduled Job is on the same cycle grid that NextChange
+	// (and the UI) uses, avoiding drift when cycleDuration doesn't divide 24h.
+	nextTime, nextState := g.FanSchedule.NextChange(clock.Now())
+	var startTime time.Time
+	if nextState {
+		// Currently OFF: next change is the start of the next ON period
+		startTime = nextTime.UTC()
+	} else {
+		// Currently ON: next change is OFF, so ON started one Duration ago
+		startTime = nextTime.UTC().Add(-g.FanSchedule.Duration.Duration)
+	}
 
 	scheduleJobsGauge.WithLabelValues(gardenLabels(g)...).Inc()
 	_, err := w.scheduler.

--- a/garden-app/worker/scheduler_test.go
+++ b/garden-app/worker/scheduler_test.go
@@ -1195,6 +1195,65 @@ func TestResetFanSchedule(t *testing.T) {
 	mqttClient.AssertExpectations(t)
 }
 
+// TestScheduleFanActions_NextRun verifies that the scheduled fan job's NextRun
+// aligns with FanSchedule.NextChange, especially when cycleDuration does not
+// evenly divide 24h. This prevents the UI and scheduler from drifting onto
+// different cycle grids.
+func TestScheduleFanActions_NextRun(t *testing.T) {
+	mockClock := clock.MockTime()
+	// 12:00 UTC with a 2h30m cycle (30m ON, 2h OFF). Cycle boundaries:
+	// 10:00 ON, 10:30 OFF, 13:00 ON, 13:30 OFF, ...
+	mockClock.Set(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC))
+	t.Cleanup(clock.Reset)
+
+	storageClient, err := storage.NewClient(storage.Config{
+		ConnectionString: ":memory:",
+	})
+	require.NoError(t, err)
+	defer weather.ResetCache()
+
+	influxdbClient := new(influxdb.MockClient)
+	mqttClient := new(mqtt.MockClient)
+	mqttClient.On("Disconnect", uint(100)).Return()
+	influxdbClient.On("Close").Return()
+
+	worker := NewWorker(storageClient, influxdbClient, mqttClient, slog.Default())
+	worker.StartAsync()
+
+	power := uint(50)
+	g := &pkg.Garden{
+		ID:          babyapi.NewID(),
+		Name:        "test-garden",
+		TopicPrefix: "test-garden",
+		FanSchedule: &pkg.FanSchedule{
+			Duration: &pkg.Duration{Duration: 30 * time.Minute},
+			Interval: &pkg.Duration{Duration: 2 * time.Hour},
+			Power:    &power,
+		},
+	}
+
+	err = worker.ScheduleFanActions(g)
+	require.NoError(t, err)
+
+	var fanJob interface{ NextRun() time.Time }
+	for _, job := range worker.scheduler.Jobs() {
+		tags := job.Tags()
+		if slices.Contains(tags, g.ID.String()) && slices.Contains(tags, "fan") {
+			fanJob = job
+			break
+		}
+	}
+
+	require.NotNil(t, fanJob, "fan job not found")
+
+	expectedNext, _ := g.FanSchedule.NextChange(clock.Now())
+	assert.True(t, expectedNext.Equal(fanJob.NextRun()), "NextRun mismatch: expected %v, got %v", expectedNext, fanJob.NextRun())
+
+	worker.Stop()
+	influxdbClient.AssertExpectations(t)
+	mqttClient.AssertExpectations(t)
+}
+
 func TestExecuteFanAction(t *testing.T) {
 	storageClient, err := storage.NewClient(storage.Config{
 		ConnectionString: ":memory:",

--- a/garden-controller/src/main.cpp
+++ b/garden-controller/src/main.cpp
@@ -66,6 +66,10 @@ void setupFan() {
     ledc_channel.duty = 0;
     ledc_channel.hpoint = 0;
     ledc_channel_config(&ledc_channel);
+
+    // Explicitly set fan to 0% on startup so it does not retain a previous duty cycle
+    ledc_set_duty(LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_1, 0);
+    ledc_update_duty(LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_1);
 }
 
 /*


### PR DESCRIPTION
- Normalize now to UTC in FanSchedule.NextChange so non-UTC timezones east of UTC no longer use a future anchor.
- Derive ScheduleFanActions StartAt from NextChange instead of yesterday midnight, keeping the gocron job on the same cycle grid as the UI.
- Add timezone and NextRun consistency tests.