### PR TITLE
feat: Manage controller setup from GardenApp (firmware update and settings)

### DIFF
--- a/garden-app/pkg/action/garden_action.go
+++ b/garden-app/pkg/action/garden_action.go
@@ -12,27 +12,40 @@ import (
 // GardenAction collects all the possible actions for a Garden into a single struct so these can easily be
 // received as one request
 type GardenAction struct {
-	Light  *LightAction  `json:"light" form:"light"`
-	Fan    *FanAction    `json:"fan" form:"fan"`
-	Stop   *StopAction   `json:"stop" form:"stop"`
-	Update *UpdateAction `json:"update" form:"update"`
+	Light           *LightAction           `json:"light" form:"light"`
+	Fan             *FanAction             `json:"fan" form:"fan"`
+	Stop            *StopAction            `json:"stop" form:"stop"`
+	Update          *UpdateAction          `json:"update" form:"update"`
+	ControllerSetup *ControllerSetupAction `json:"controller_setup" form:"controller_setup"`
 }
 
 // String returns a string representation of the GardenAction
 func (action *GardenAction) String() string {
-	return fmt.Sprintf("{LightAction: %+v, FanAction: %+v, StopAction: %+v, UpdateAction: %+v}", action.Light, action.Fan, action.Stop, action.Update)
+	return fmt.Sprintf("{LightAction: %+v, FanAction: %+v, StopAction: %+v, UpdateAction: %+v, ControllerSetupAction: %+v}", action.Light, action.Fan, action.Stop, action.Update, action.ControllerSetup)
 }
 
 // Bind is used to make this struct compatible with our REST API implemented with go-chi.
 // It will verify that the request is valid
 func (action *GardenAction) Bind(_ *http.Request) error {
-	if action == nil || (action.Light == nil && action.Fan == nil && action.Stop == nil && action.Update == nil) {
+	if action == nil || (action.Light == nil && action.Fan == nil && action.Stop == nil && action.Update == nil && action.ControllerSetup == nil) {
 		return errors.New("missing required action fields")
 	}
 
 	if action.Update != nil {
 		if !action.Update.Config {
 			return errors.New("update action must have config=true")
+		}
+	}
+
+	if action.ControllerSetup != nil {
+		if action.ControllerSetup.Server == "" {
+			return errors.New("controller_setup action must have server")
+		}
+		if action.ControllerSetup.TopicPrefix == "" {
+			return errors.New("controller_setup action must have topic_prefix")
+		}
+		if action.ControllerSetup.Port <= 0 {
+			return errors.New("controller_setup action must have a positive port")
 		}
 	}
 	return nil
@@ -59,4 +72,12 @@ type UpdateAction struct {
 type FanAction struct {
 	Duration int64 `json:"duration" form:"duration"`
 	Power    uint8 `json:"power" form:"power"`
+}
+
+// ControllerSetupAction is used to send MQTT connection details to the controller's
+// WiFiManager setup endpoint
+type ControllerSetupAction struct {
+	Server      string `json:"server" form:"server"`
+	TopicPrefix string `json:"topic_prefix" form:"topic_prefix"`
+	Port        int    `json:"port" form:"port"`
 }

--- a/garden-app/pkg/action/garden_action.go
+++ b/garden-app/pkg/action/garden_action.go
@@ -17,17 +17,18 @@ type GardenAction struct {
 	Stop            *StopAction            `json:"stop" form:"stop"`
 	Update          *UpdateAction          `json:"update" form:"update"`
 	ControllerSetup *ControllerSetupAction `json:"controller_setup" form:"controller_setup"`
+	FirmwareUpdate  *FirmwareUpdateAction  `json:"firmware_update" form:"firmware_update"`
 }
 
 // String returns a string representation of the GardenAction
 func (action *GardenAction) String() string {
-	return fmt.Sprintf("{LightAction: %+v, FanAction: %+v, StopAction: %+v, UpdateAction: %+v, ControllerSetupAction: %+v}", action.Light, action.Fan, action.Stop, action.Update, action.ControllerSetup)
+	return fmt.Sprintf("{LightAction: %+v, FanAction: %+v, StopAction: %+v, UpdateAction: %+v, ControllerSetupAction: %+v, FirmwareUpdateAction: %+v}", action.Light, action.Fan, action.Stop, action.Update, action.ControllerSetup, action.FirmwareUpdate)
 }
 
 // Bind is used to make this struct compatible with our REST API implemented with go-chi.
 // It will verify that the request is valid
 func (action *GardenAction) Bind(_ *http.Request) error {
-	if action == nil || (action.Light == nil && action.Fan == nil && action.Stop == nil && action.Update == nil && action.ControllerSetup == nil) {
+	if action == nil || (action.Light == nil && action.Fan == nil && action.Stop == nil && action.Update == nil && action.ControllerSetup == nil && action.FirmwareUpdate == nil) {
 		return errors.New("missing required action fields")
 	}
 
@@ -80,4 +81,12 @@ type ControllerSetupAction struct {
 	Server      string `json:"server" form:"server"`
 	TopicPrefix string `json:"topic_prefix" form:"topic_prefix"`
 	Port        int    `json:"port" form:"port"`
+}
+
+// FirmwareUpdateAction is used to update the controller's firmware via the WiFiManager
+// update endpoint. When Latest is true, the firmware is fetched from the GitHub release
+// tagged controller-latest; otherwise FileData must be provided.
+type FirmwareUpdateAction struct {
+	Latest   bool   `json:"latest" form:"latest"`
+	FileData []byte `json:"-" form:"-"`
 }

--- a/garden-app/pkg/action/garden_action_test.go
+++ b/garden-app/pkg/action/garden_action_test.go
@@ -33,6 +33,21 @@ func TestGardenActionBind(t *testing.T) {
 			&GardenAction{Update: &UpdateAction{}},
 			"update action must have config=true",
 		},
+		{
+			"ErrorMissingControllerSetupServer",
+			&GardenAction{ControllerSetup: &ControllerSetupAction{TopicPrefix: "garden", Port: 1883}},
+			"controller_setup action must have server",
+		},
+		{
+			"ErrorMissingControllerSetupTopicPrefix",
+			&GardenAction{ControllerSetup: &ControllerSetupAction{Server: "192.168.0.1", Port: 1883}},
+			"controller_setup action must have topic_prefix",
+		},
+		{
+			"ErrorMissingControllerSetupPort",
+			&GardenAction{ControllerSetup: &ControllerSetupAction{Server: "192.168.0.1", TopicPrefix: "garden"}},
+			"controller_setup action must have a positive port",
+		},
 	}
 
 	t.Run("SuccessfulLightAction", func(t *testing.T) {
@@ -50,6 +65,20 @@ func TestGardenActionBind(t *testing.T) {
 	t.Run("SuccessfulStopAction", func(t *testing.T) {
 		ar := &GardenAction{
 			Stop: &StopAction{},
+		}
+		r := httptest.NewRequest("", "/", nil)
+		err := ar.Bind(r)
+		if err != nil {
+			t.Errorf("Unexpected error reading GardenAction JSON: %v", err)
+		}
+	})
+	t.Run("SuccessfulControllerSetupAction", func(t *testing.T) {
+		ar := &GardenAction{
+			ControllerSetup: &ControllerSetupAction{
+				Server:      "192.168.0.1",
+				TopicPrefix: "garden",
+				Port:        1883,
+			},
 		}
 		r := httptest.NewRequest("", "/", nil)
 		err := ar.Bind(r)

--- a/garden-app/pkg/action/garden_action_test.go
+++ b/garden-app/pkg/action/garden_action_test.go
@@ -86,6 +86,18 @@ func TestGardenActionBind(t *testing.T) {
 			t.Errorf("Unexpected error reading GardenAction JSON: %v", err)
 		}
 	})
+	t.Run("SuccessfulFirmwareUpdateLatestAction", func(t *testing.T) {
+		ar := &GardenAction{
+			FirmwareUpdate: &FirmwareUpdateAction{
+				Latest: true,
+			},
+		}
+		r := httptest.NewRequest("", "/", nil)
+		err := ar.Bind(r)
+		if err != nil {
+			t.Errorf("Unexpected error reading GardenAction JSON: %v", err)
+		}
+	})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := httptest.NewRequest("", "/", nil)

--- a/garden-app/server/garden.go
+++ b/garden-app/server/garden.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"iter"
 	"net/http"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -22,7 +24,8 @@ import (
 )
 
 const (
-	gardenBasePath = "/gardens"
+	gardenBasePath        = "/gardens"
+	maxFirmwareUploadSize = 3 * 1024 * 1024 // 3 MB
 )
 
 // GardensAPI encapsulates the structs and dependencies necessary for the "/gardens" API
@@ -269,8 +272,15 @@ func (api *GardensAPI) gardenAction(_ http.ResponseWriter, r *http.Request, gard
 		return nil, babyapi.ErrInvalidRequest(errors.New("unable to execute action on end-dated garden"))
 	}
 
-	gardenAction := &action.GardenAction{}
-	if err := render.Bind(r, gardenAction); err != nil {
+	var gardenAction *action.GardenAction
+	var err error
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data") {
+		gardenAction, err = parseFirmwareUpdateAction(r)
+	} else {
+		gardenAction = &action.GardenAction{}
+		err = render.Bind(r, gardenAction)
+	}
+	if err != nil {
 		logger.Error("invalid request for GardenAction", "error", err)
 		return nil, babyapi.ErrInvalidRequest(err)
 	}
@@ -283,6 +293,44 @@ func (api *GardensAPI) gardenAction(_ http.ResponseWriter, r *http.Request, gard
 
 	render.Status(r, http.StatusAccepted)
 	return &GardenActionResponse{}, nil
+}
+
+func parseFirmwareUpdateAction(r *http.Request) (*action.GardenAction, error) {
+	err := r.ParseMultipartForm(int64(maxFirmwareUploadSize + 1024))
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse multipart form: %w", err)
+	}
+
+	latest := r.FormValue("firmware_update.latest") == "true"
+
+	fwAction := &action.FirmwareUpdateAction{
+		Latest: latest,
+	}
+
+	if !latest {
+		file, header, err := r.FormFile("firmware_update.file")
+		if err != nil {
+			return nil, errors.New("firmware_update file is required when latest is not true")
+		}
+		defer func() { _ = file.Close() }()
+
+		if filepath.Ext(header.Filename) != ".bin" {
+			return nil, errors.New("firmware file must have .bin extension")
+		}
+
+		fwAction.FileData, err = io.ReadAll(io.LimitReader(file, int64(maxFirmwareUploadSize)+1))
+		if err != nil {
+			return nil, fmt.Errorf("unable to read firmware file: %w", err)
+		}
+
+		if len(fwAction.FileData) > maxFirmwareUploadSize {
+			return nil, errors.New("firmware file exceeds maximum size of 3 MB")
+		}
+	}
+
+	return &action.GardenAction{
+		FirmwareUpdate: fwAction,
+	}, nil
 }
 
 // gardenWaterHistory responds with recent water events for all Zones in a Garden

--- a/garden-app/server/garden_test.go
+++ b/garden-app/server/garden_test.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -827,6 +829,164 @@ func TestGardenActionForm(t *testing.T) {
 			assert.Equal(t, tt.status, w.Code)
 			assert.Equal(t, tt.expected, strings.TrimSpace(w.Body.String()))
 			mqttClient.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGardenActionFirmwareUpdate(t *testing.T) {
+	firmwareData := []byte("fake firmware binary data")
+
+	uploadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/u", r.URL.Path)
+		assert.True(t, strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data"))
+
+		r.Body = http.MaxBytesReader(w, r.Body, int64(maxFirmwareUploadSize+1024))
+		err := r.ParseMultipartForm(int64(maxFirmwareUploadSize + 1024))
+		assert.NoError(t, err)
+
+		file, header, err := r.FormFile("update")
+		assert.NoError(t, err)
+		defer func() { _ = file.Close() }()
+
+		assert.Equal(t, "firmware.bin", header.Filename)
+
+		received, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Equal(t, firmwareData, received)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer uploadServer.Close()
+
+	assetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/firmware.bin", r.URL.Path)
+		_, _ = w.Write(firmwareData)
+	}))
+	defer assetServer.Close()
+
+	releaseServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/releases/tags/controller-latest", r.URL.Path)
+		_, _ = fmt.Fprintf(w, `{"assets":[{"name":"firmware.bin","browser_download_url":"%s/firmware.bin"}]}`, assetServer.URL)
+	}))
+	defer releaseServer.Close()
+
+	tests := []struct {
+		name         string
+		buildRequest func(string) *http.Request
+		expected     string
+		status       int
+	}{
+		{
+			"SuccessfulDirectUpload",
+			func(path string) *http.Request {
+				var body bytes.Buffer
+				writer := multipart.NewWriter(&body)
+				_ = writer.WriteField("firmware_update.latest", "false")
+				part, _ := writer.CreateFormFile("firmware_update.file", "firmware.bin")
+				_, _ = part.Write(firmwareData)
+				_ = writer.Close()
+
+				r := httptest.NewRequest(http.MethodPost, path, &body)
+				r.Header.Set("Content-Type", writer.FormDataContentType())
+				return r
+			},
+			"{}",
+			http.StatusAccepted,
+		},
+		{
+			"SuccessfulLatest",
+			func(path string) *http.Request {
+				var body bytes.Buffer
+				writer := multipart.NewWriter(&body)
+				_ = writer.WriteField("firmware_update.latest", "true")
+				_ = writer.Close()
+
+				r := httptest.NewRequest(http.MethodPost, path, &body)
+				r.Header.Set("Content-Type", writer.FormDataContentType())
+				return r
+			},
+			"{}",
+			http.StatusAccepted,
+		},
+		{
+			"InvalidExtension",
+			func(path string) *http.Request {
+				var body bytes.Buffer
+				writer := multipart.NewWriter(&body)
+				_ = writer.WriteField("firmware_update.latest", "false")
+				part, _ := writer.CreateFormFile("firmware_update.file", "firmware.txt")
+				_, _ = part.Write(firmwareData)
+				_ = writer.Close()
+
+				r := httptest.NewRequest(http.MethodPost, path, &body)
+				r.Header.Set("Content-Type", writer.FormDataContentType())
+				return r
+			},
+			`{"status":"Invalid request.","error":"firmware file must have .bin extension"}`,
+			http.StatusBadRequest,
+		},
+		{
+			"FileTooLarge",
+			func(path string) *http.Request {
+				var body bytes.Buffer
+				writer := multipart.NewWriter(&body)
+				_ = writer.WriteField("firmware_update.latest", "false")
+				part, _ := writer.CreateFormFile("firmware_update.file", "firmware.bin")
+				_, _ = part.Write(make([]byte, maxFirmwareUploadSize+1))
+				_ = writer.Close()
+
+				r := httptest.NewRequest(http.MethodPost, path, &body)
+				r.Header.Set("Content-Type", writer.FormDataContentType())
+				return r
+			},
+			`{"status":"Invalid request.","error":"firmware file exceeds maximum size of 3 MB"}`,
+			http.StatusBadRequest,
+		},
+		{
+			"MissingFile",
+			func(path string) *http.Request {
+				var body bytes.Buffer
+				writer := multipart.NewWriter(&body)
+				_ = writer.WriteField("firmware_update.latest", "false")
+				_ = writer.Close()
+
+				r := httptest.NewRequest(http.MethodPost, path, &body)
+				r.Header.Set("Content-Type", writer.FormDataContentType())
+				return r
+			},
+			`{"status":"Invalid request.","error":"firmware_update file is required when latest is not true"}`,
+			http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mqttClient := new(mqtt.MockClient)
+
+			storageClient, err := storage.NewClient(storage.Config{
+				ConnectionString: ":memory:",
+			})
+			assert.NoError(t, err)
+
+			w := worker.NewWorker(storageClient, nil, mqttClient, slog.Default(),
+				worker.WithFirmwareUpdateUploadURLFunc(func(string) string { return uploadServer.URL + "/u" }),
+				worker.WithFirmwareUpdateReleaseURLFunc(func() string { return releaseServer.URL + "/releases/tags/controller-latest" }),
+			)
+
+			gr := NewGardenAPI()
+			err = gr.setup(Config{}, storageClient, nil, w)
+			assert.NoError(t, err)
+
+			garden := createExampleGarden()
+			err = storageClient.Gardens.Set(context.Background(), garden)
+			assert.NoError(t, err)
+
+			r := tt.buildRequest(fmt.Sprintf("/gardens/%s/action", garden.ID))
+			resp := babytest.TestRequest[*pkg.Garden](t, gr.API, r)
+
+			assert.Equal(t, tt.status, resp.Code)
+			assert.Equal(t, tt.expected, strings.TrimSpace(resp.Body.String()))
 		})
 	}
 }

--- a/garden-app/server/templates/gardens.html
+++ b/garden-app/server/templates/gardens.html
@@ -235,6 +235,11 @@
                     <span uk-icon="cog"></span> Controller Setup
                 </a>
             </li>
+            <li>
+                <a href="#firmware-update-confirm-{{ .ID }}" uk-toggle>
+                    <span uk-icon="download"></span> Update Firmware
+                </a>
+            </li>
             {{- if .ControllerConfig }}
             <li>
                 <a href="#update-config-confirm-{{ .ID }}" uk-toggle>
@@ -248,6 +253,7 @@
 
 {{ template "stopWateringConfirmationModal" . }}
 {{ template "controllerSetupConfirmationModal" . }}
+{{ template "firmwareUpdateConfirmationModal" . }}
 {{ template "updateConfigConfirmationModal" . }}
 {{ end }}
 
@@ -342,6 +348,41 @@
                 {{ template "actionFeedback" "primary" }}
                 onclick="UIkit.modal('#controller-setup-confirm-{{ .ID }}').hide()">
                 <span uk-icon="cog"></span> Save Setup
+            </button>
+        </p>
+    </div>
+</div>
+{{ end }}
+
+{{ define "firmwareUpdateConfirmationModal" }}
+<div id="firmware-update-confirm-{{ .ID }}" class="uk-modal" uk-modal>
+    <div class="uk-modal-dialog uk-modal-body">
+        <h3 class="uk-modal-title">Update Firmware</h3>
+        <p>Upload a new firmware image for <strong>{{ .Name }}</strong>.</p>
+
+        <form id="firmware-update-form-{{ .ID }}" hx-encoding="multipart/form-data">
+            <div class="uk-margin">
+                <label>
+                    <input class="uk-checkbox" type="checkbox" name="firmware_update.latest" value="true"
+                        onchange="var f=document.getElementById('firmware-update-file-{{ .ID }}'); f.classList.toggle('uk-hidden', this.checked); f.querySelector('input').disabled = this.checked;">
+                    Use latest release
+                </label>
+            </div>
+            <div id="firmware-update-file-{{ .ID }}" class="uk-margin">
+                <input type="file" name="firmware_update.file" accept=".bin">
+            </div>
+        </form>
+
+        <p class="uk-text-right">
+            <button class="uk-button uk-button-default uk-modal-close" type="button">Cancel</button>
+            <button class="uk-button uk-button-primary" type="button"
+                hx-post="/gardens/{{ .ID }}/action"
+                hx-include="#firmware-update-form-{{ .ID }}"
+                hx-encoding="multipart/form-data"
+                hx-swap="none"
+                {{ template "actionFeedback" "primary" }}
+                onclick="UIkit.modal('#firmware-update-confirm-{{ .ID }}').hide()">
+                <span uk-icon="download"></span> Update Firmware
             </button>
         </p>
     </div>

--- a/garden-app/server/templates/gardens.html
+++ b/garden-app/server/templates/gardens.html
@@ -230,6 +230,11 @@
                     <span uk-icon="ban"></span> Stop Watering
                 </a>
             </li>
+            <li>
+                <a href="#controller-setup-confirm-{{ .ID }}" uk-toggle>
+                    <span uk-icon="cog"></span> Controller Setup
+                </a>
+            </li>
             {{- if .ControllerConfig }}
             <li>
                 <a href="#update-config-confirm-{{ .ID }}" uk-toggle>
@@ -242,6 +247,7 @@
 </div>
 
 {{ template "stopWateringConfirmationModal" . }}
+{{ template "controllerSetupConfirmationModal" . }}
 {{ template "updateConfigConfirmationModal" . }}
 {{ end }}
 
@@ -303,6 +309,39 @@
                 {{ template "actionFeedback" "primary" }}
                 onclick="UIkit.modal('#update-config-confirm-{{ .ID }}').hide()">
                 <span uk-icon="push"></span> Update Config
+            </button>
+        </p>
+    </div>
+</div>
+{{ end }}
+
+{{ define "controllerSetupConfirmationModal" }}
+<div id="controller-setup-confirm-{{ .ID }}" class="uk-modal" uk-modal>
+    <div class="uk-modal-dialog uk-modal-body">
+        <h3 class="uk-modal-title">Controller Setup</h3>
+        <p>Configure MQTT settings for <strong>{{ .Name }}</strong>.</p>
+
+        <form id="controller-setup-form-{{ .ID }}">
+            <div class="uk-margin">
+                <input class="uk-input" type="text" name="controller_setup.server" placeholder="MQTT Server" value="192.168.0.1">
+            </div>
+            <div class="uk-margin">
+                <input class="uk-input" type="text" name="controller_setup.topic_prefix" placeholder="Topic Prefix" value="{{ .TopicPrefix }}">
+            </div>
+            <div class="uk-margin">
+                <input class="uk-input" type="number" name="controller_setup.port" placeholder="MQTT Port" value="1883">
+            </div>
+        </form>
+
+        <p class="uk-text-right">
+            <button class="uk-button uk-button-default uk-modal-close" type="button">Cancel</button>
+            <button class="uk-button uk-button-primary" type="button"
+                hx-post="/gardens/{{ .ID }}/action"
+                hx-include="#controller-setup-form-{{ .ID }}"
+                hx-swap="none"
+                {{ template "actionFeedback" "primary" }}
+                onclick="UIkit.modal('#controller-setup-confirm-{{ .ID }}').hide()">
+                <span uk-icon="cog"></span> Save Setup
             </button>
         </p>
     </div>

--- a/garden-app/worker/garden_action_test.go
+++ b/garden-app/worker/garden_action_test.go
@@ -2,11 +2,14 @@ package worker
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -408,4 +411,144 @@ func TestControllerSetupActionExecute(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFirmwareUpdateActionExecute(t *testing.T) {
+	garden := &pkg.Garden{
+		Name:        "garden",
+		TopicPrefix: "garden",
+	}
+
+	firmwareData := []byte("fake firmware binary data")
+
+	tests := []struct {
+		name         string
+		action       *action.FirmwareUpdateAction
+		setupServers func() (releaseURL, uploadURL string)
+		assert       func(error, []byte, *testing.T)
+	}{
+		{
+			"SuccessfulDirectUpload",
+			&action.FirmwareUpdateAction{
+				Latest:   false,
+				FileData: firmwareData,
+			},
+			func() (string, string) {
+				return "", newFirmwareUploadServer(t, firmwareData, http.StatusOK)
+			},
+			func(err error, _ []byte, t *testing.T) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			"SuccessfulLatest",
+			&action.FirmwareUpdateAction{
+				Latest: true,
+			},
+			func() (string, string) {
+				assetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, "/firmware.bin", r.URL.Path)
+					_, _ = w.Write(firmwareData)
+				}))
+
+				releaseServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, "/releases/tags/controller-latest", r.URL.Path)
+					_, _ = fmt.Fprintf(w, `{"assets":[{"name":"firmware.bin","browser_download_url":"%s/firmware.bin"}]}`, assetServer.URL)
+				}))
+
+				uploadServer := newFirmwareUploadServer(t, firmwareData, http.StatusOK)
+				return releaseServer.URL + "/releases/tags/controller-latest", uploadServer
+			},
+			func(err error, _ []byte, t *testing.T) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			"MissingFile",
+			&action.FirmwareUpdateAction{
+				Latest: false,
+			},
+			func() (string, string) {
+				return "", ""
+			},
+			func(err error, _ []byte, t *testing.T) {
+				assert.Error(t, err)
+				assert.Equal(t, "firmware_update action must have a file or latest=true", err.Error())
+			},
+		},
+		{
+			"FileTooLarge",
+			&action.FirmwareUpdateAction{
+				Latest:   false,
+				FileData: make([]byte, maxFirmwareSize+1),
+			},
+			func() (string, string) {
+				return "", ""
+			},
+			func(err error, _ []byte, t *testing.T) {
+				assert.Error(t, err)
+				assert.Equal(t, fmt.Sprintf("firmware exceeds maximum size of %d bytes", maxFirmwareSize), err.Error())
+			},
+		},
+		{
+			"ControllerError",
+			&action.FirmwareUpdateAction{
+				Latest:   false,
+				FileData: firmwareData,
+			},
+			func() (string, string) {
+				return "", newFirmwareUploadServer(t, firmwareData, http.StatusInternalServerError)
+			},
+			func(err error, _ []byte, t *testing.T) {
+				assert.Error(t, err)
+				assert.Equal(t, "firmware update request returned status 500", err.Error())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			releaseURL, uploadURL := tt.setupServers()
+
+			worker := NewWorker(nil, nil, nil, slog.Default())
+			if releaseURL != "" {
+				worker.firmwareUpdateReleaseURLFunc = func() string { return releaseURL }
+			}
+			if uploadURL != "" {
+				worker.firmwareUpdateUploadURLFunc = func(string) string { return uploadURL }
+			}
+
+			err := worker.ExecuteFirmwareUpdateAction(garden, tt.action)
+			tt.assert(err, firmwareData, t)
+		})
+	}
+}
+
+func newFirmwareUploadServer(t *testing.T, expectedData []byte, status int) string {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/u", r.URL.Path)
+		assert.True(t, strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data"))
+
+		r.Body = http.MaxBytesReader(w, r.Body, int64(maxFirmwareSize+1024))
+		err := r.ParseMultipartForm(int64(maxFirmwareSize + 1024))
+		assert.NoError(t, err)
+
+		file, header, err := r.FormFile("update")
+		assert.NoError(t, err)
+		defer func() { _ = file.Close() }()
+
+		assert.Equal(t, "firmware.bin", header.Filename)
+
+		received, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedData, received)
+
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(server.Close)
+
+	return server.URL + "/u"
 }

--- a/garden-app/worker/garden_action_test.go
+++ b/garden-app/worker/garden_action_test.go
@@ -3,6 +3,10 @@ package worker
 import (
 	"errors"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
@@ -282,6 +286,126 @@ func TestStopActionExecute(t *testing.T) {
 			tt.assert(err, t)
 			mqttClient.AssertExpectations(t)
 			influxdbClient.AssertExpectations(t)
+		})
+	}
+}
+
+func TestControllerSetupActionExecute(t *testing.T) {
+	garden := &pkg.Garden{
+		Name:        "garden",
+		TopicPrefix: "garden",
+	}
+
+	tests := []struct {
+		name         string
+		action       *action.ControllerSetupAction
+		serverStatus int
+		assert       func(error, *testing.T)
+	}{
+		{
+			"Successful",
+			&action.ControllerSetupAction{
+				Server:      "192.168.0.1",
+				TopicPrefix: "garden",
+				Port:        1883,
+			},
+			http.StatusOK,
+			func(err error, t *testing.T) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			"SuccessfulRedirect",
+			&action.ControllerSetupAction{
+				Server:      "192.168.0.1",
+				TopicPrefix: "garden",
+				Port:        1883,
+			},
+			http.StatusFound,
+			func(err error, t *testing.T) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			"MissingServer",
+			&action.ControllerSetupAction{
+				TopicPrefix: "garden",
+				Port:        1883,
+			},
+			http.StatusOK,
+			func(err error, t *testing.T) {
+				assert.Error(t, err)
+				assert.Equal(t, "controller_setup action must have server", err.Error())
+			},
+		},
+		{
+			"MissingTopicPrefix",
+			&action.ControllerSetupAction{
+				Server: "192.168.0.1",
+				Port:   1883,
+			},
+			http.StatusOK,
+			func(err error, t *testing.T) {
+				assert.Error(t, err)
+				assert.Equal(t, "controller_setup action must have topic_prefix", err.Error())
+			},
+		},
+		{
+			"InvalidPort",
+			&action.ControllerSetupAction{
+				Server:      "192.168.0.1",
+				TopicPrefix: "garden",
+				Port:        0,
+			},
+			http.StatusOK,
+			func(err error, t *testing.T) {
+				assert.Error(t, err)
+				assert.Equal(t, "controller_setup action must have a positive port", err.Error())
+			},
+		},
+		{
+			"ServerError",
+			&action.ControllerSetupAction{
+				Server:      "192.168.0.1",
+				TopicPrefix: "garden",
+				Port:        1883,
+			},
+			http.StatusInternalServerError,
+			func(err error, t *testing.T) {
+				assert.Error(t, err)
+				assert.Equal(t, "controller setup request returned status 500", err.Error())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			received := url.Values{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/paramsave", r.URL.Path)
+				assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+
+				r.Body = http.MaxBytesReader(w, r.Body, 1024)
+				err := r.ParseForm()
+				assert.NoError(t, err)
+				received = r.PostForm
+
+				w.WriteHeader(tt.serverStatus)
+			}))
+			defer server.Close()
+
+			worker := NewWorker(nil, nil, nil, slog.Default())
+			worker.controllerSetupURLFunc = func(string) string { return server.URL + "/paramsave" }
+
+			err := worker.ExecuteControllerSetupAction(garden, tt.action)
+			tt.assert(err, t)
+
+			if err == nil {
+				assert.Equal(t, tt.action.Server, received.Get("server"))
+				assert.Equal(t, tt.action.TopicPrefix, received.Get("topic_prefix"))
+				assert.Equal(t, strconv.Itoa(tt.action.Port), received.Get("port"))
+			}
 		})
 	}
 }

--- a/garden-app/worker/garden_actions.go
+++ b/garden-app/worker/garden_actions.go
@@ -2,10 +2,13 @@
 package worker
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -43,6 +46,11 @@ func (w *Worker) ExecuteGardenAction(g *pkg.Garden, input *action.GardenAction) 
 		err := w.ExecuteControllerSetupAction(g, input.ControllerSetup)
 		if err != nil {
 			return fmt.Errorf("unable to execute ControllerSetupAction: %v", err)
+		}
+	case input.FirmwareUpdate != nil:
+		err := w.ExecuteFirmwareUpdateAction(g, input.FirmwareUpdate)
+		if err != nil {
+			return fmt.Errorf("unable to execute FirmwareUpdateAction: %v", err)
 		}
 	}
 	return nil
@@ -166,4 +174,127 @@ func (w *Worker) ExecuteControllerSetupAction(g *pkg.Garden, input *action.Contr
 	}
 
 	return nil
+}
+
+// ExecuteFirmwareUpdateAction sends a firmware image to the controller's WiFiManager
+// update endpoint. When input.Latest is true, the image is downloaded from the
+// controller-latest GitHub release.
+func (w *Worker) ExecuteFirmwareUpdateAction(g *pkg.Garden, input *action.FirmwareUpdateAction) error {
+	var firmware []byte
+	var err error
+
+	if input.Latest {
+		firmware, err = w.downloadLatestFirmware()
+		if err != nil {
+			return fmt.Errorf("unable to download latest firmware: %v", err)
+		}
+	} else {
+		if len(input.FileData) == 0 {
+			return errors.New("firmware_update action must have a file or latest=true")
+		}
+		firmware = input.FileData
+	}
+
+	if len(firmware) > maxFirmwareSize {
+		return fmt.Errorf("firmware exceeds maximum size of %d bytes", maxFirmwareSize)
+	}
+
+	endpoint := w.firmwareUpdateUploadURLFunc(g.TopicPrefix)
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("update", firmwareAssetName)
+	if err != nil {
+		return fmt.Errorf("unable to create firmware form file: %v", err)
+	}
+	_, err = part.Write(firmware)
+	if err != nil {
+		return fmt.Errorf("unable to write firmware form file: %v", err)
+	}
+	err = writer.Close()
+	if err != nil {
+		return fmt.Errorf("unable to close firmware multipart writer: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, body)
+	if err != nil {
+		return fmt.Errorf("unable to create firmware update request: %v", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := w.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("unable to send firmware update request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("firmware update request returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+type githubRelease struct {
+	Assets []githubAsset `json:"assets"`
+}
+
+type githubAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+func (w *Worker) downloadLatestFirmware() ([]byte, error) {
+	releaseURL := w.firmwareUpdateReleaseURLFunc()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, releaseURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create release request: %v", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := w.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch release: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("release request returned status %d", resp.StatusCode)
+	}
+
+	var release githubRelease
+	decoder := json.NewDecoder(io.LimitReader(resp.Body, 1024*1024))
+	err = decoder.Decode(&release)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode release response: %v", err)
+	}
+
+	var downloadURL string
+	for _, asset := range release.Assets {
+		if asset.Name == firmwareAssetName {
+			downloadURL = asset.BrowserDownloadURL
+			break
+		}
+	}
+	if downloadURL == "" {
+		return nil, fmt.Errorf("release does not contain %q asset", firmwareAssetName)
+	}
+
+	req, err = http.NewRequestWithContext(context.Background(), http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create asset request: %v", err)
+	}
+
+	resp, err = w.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch asset: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("asset request returned status %d", resp.StatusCode)
+	}
+
+	return io.ReadAll(io.LimitReader(resp.Body, int64(maxFirmwareSize)+1))
 }

--- a/garden-app/worker/garden_actions.go
+++ b/garden-app/worker/garden_actions.go
@@ -2,9 +2,14 @@
 package worker
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
 
 	"github.com/calvinmclean/automated-garden/garden-app/pkg"
 	"github.com/calvinmclean/automated-garden/garden-app/pkg/action"
@@ -33,6 +38,11 @@ func (w *Worker) ExecuteGardenAction(g *pkg.Garden, input *action.GardenAction) 
 		err := w.ExecuteUpdateAction(g, input.Update)
 		if err != nil {
 			return fmt.Errorf("unable to execute UpdateAction: %v", err)
+		}
+	case input.ControllerSetup != nil:
+		err := w.ExecuteControllerSetupAction(g, input.ControllerSetup)
+		if err != nil {
+			return fmt.Errorf("unable to execute ControllerSetupAction: %v", err)
 		}
 	}
 	return nil
@@ -114,6 +124,45 @@ func (w *Worker) ExecuteUpdateAction(g *pkg.Garden, input *action.UpdateAction) 
 	err = w.mqttClient.Publish(topic, msg)
 	if err != nil {
 		return fmt.Errorf("unable to publish UpdateAction: %v", err)
+	}
+
+	return nil
+}
+
+// ExecuteControllerSetupAction sends MQTT connection details to the controller's
+// WiFiManager paramsave endpoint
+func (w *Worker) ExecuteControllerSetupAction(g *pkg.Garden, input *action.ControllerSetupAction) error {
+	if input.Server == "" {
+		return errors.New("controller_setup action must have server")
+	}
+	if input.TopicPrefix == "" {
+		return errors.New("controller_setup action must have topic_prefix")
+	}
+	if input.Port <= 0 {
+		return errors.New("controller_setup action must have a positive port")
+	}
+
+	endpoint := w.controllerSetupURLFunc(g.TopicPrefix)
+
+	form := url.Values{}
+	form.Set("server", input.Server)
+	form.Set("topic_prefix", input.TopicPrefix)
+	form.Set("port", strconv.Itoa(input.Port))
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("unable to create controller setup request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := w.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("unable to send controller setup request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("controller setup request returned status %d", resp.StatusCode)
 	}
 
 	return nil

--- a/garden-app/worker/worker.go
+++ b/garden-app/worker/worker.go
@@ -17,6 +17,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	maxFirmwareSize      = 3 * 1024 * 1024 // 3 MB
+	firmwareAssetName    = "firmware.bin"
+	controllerReleaseTag = "controller-latest"
+	githubRepo           = "calvinmclean/automated-garden"
+)
+
 var (
 	scheduleJobsGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "garden_app",
@@ -52,6 +59,14 @@ type Worker struct {
 	// It is overridable for tests.
 	controllerSetupURLFunc func(topicPrefix string) string
 
+	// firmwareUpdateReleaseURLFunc returns the GitHub API URL for the controller-latest release.
+	// It is overridable for tests.
+	firmwareUpdateReleaseURLFunc func() string
+
+	// firmwareUpdateUploadURLFunc builds the URL for the controller's WiFiManager update endpoint.
+	// It is overridable for tests.
+	firmwareUpdateUploadURLFunc func(topicPrefix string) string
+
 	// When Garden health messages are received, Timers are created to track their
 	// uptime and notify if they go down
 	downTimers map[string]clock.Timer
@@ -64,6 +79,27 @@ type WorkerOption func(*Worker)
 func WithHTTPClient(client *http.Client) WorkerOption {
 	return func(w *Worker) {
 		w.httpClient = client
+	}
+}
+
+// WithControllerSetupURLFunc overrides the URL builder for controller setup requests
+func WithControllerSetupURLFunc(fn func(topicPrefix string) string) WorkerOption {
+	return func(w *Worker) {
+		w.controllerSetupURLFunc = fn
+	}
+}
+
+// WithFirmwareUpdateReleaseURLFunc overrides the GitHub release URL used for latest firmware updates
+func WithFirmwareUpdateReleaseURLFunc(fn func() string) WorkerOption {
+	return func(w *Worker) {
+		w.firmwareUpdateReleaseURLFunc = fn
+	}
+}
+
+// WithFirmwareUpdateUploadURLFunc overrides the URL builder for firmware upload requests
+func WithFirmwareUpdateUploadURLFunc(fn func(topicPrefix string) string) WorkerOption {
+	return func(w *Worker) {
+		w.firmwareUpdateUploadURLFunc = fn
 	}
 }
 
@@ -87,6 +123,12 @@ func NewWorker(
 		httpClient:     http.DefaultClient,
 		controllerSetupURLFunc: func(topicPrefix string) string {
 			return fmt.Sprintf("http://%s.local/paramsave", topicPrefix)
+		},
+		firmwareUpdateReleaseURLFunc: func() string {
+			return fmt.Sprintf("https://api.github.com/repos/%s/releases/tags/%s", githubRepo, controllerReleaseTag)
+		},
+		firmwareUpdateUploadURLFunc: func(topicPrefix string) string {
+			return fmt.Sprintf("http://%s.local/u", topicPrefix)
 		},
 	}
 

--- a/garden-app/worker/worker.go
+++ b/garden-app/worker/worker.go
@@ -2,7 +2,9 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"net/http"
 	"sync"
 	"time"
 
@@ -44,10 +46,25 @@ type Worker struct {
 	mqttClient     mqtt.Client
 	scheduler      *gocron.Scheduler
 	logger         *slog.Logger
+	httpClient     *http.Client
+
+	// controllerSetupURLFunc builds the URL for the controller's WiFiManager paramsave endpoint.
+	// It is overridable for tests.
+	controllerSetupURLFunc func(topicPrefix string) string
 
 	// When Garden health messages are received, Timers are created to track their
 	// uptime and notify if they go down
 	downTimers map[string]clock.Timer
+}
+
+// WorkerOption configures a Worker during creation
+type WorkerOption func(*Worker)
+
+// WithHTTPClient sets the HTTP client used for controller setup requests
+func WithHTTPClient(client *http.Client) WorkerOption {
+	return func(w *Worker) {
+		w.httpClient = client
+	}
 }
 
 // NewWorker creates a Worker with specified clients
@@ -56,17 +73,28 @@ func NewWorker(
 	influxdbClient influxdb.Client,
 	mqttClient mqtt.Client,
 	logger *slog.Logger,
+	options ...WorkerOption,
 ) *Worker {
 	scheduler := gocron.NewScheduler(time.UTC)
 	scheduler.CustomTime(clock.DefaultClock)
-	return &Worker{
+	w := &Worker{
 		storageClient:  storageClient,
 		influxdbClient: influxdbClient,
 		mqttClient:     mqttClient,
 		scheduler:      scheduler,
 		logger:         logger.With("source", "worker"),
 		downTimers:     map[string]clock.Timer{},
+		httpClient:     http.DefaultClient,
+		controllerSetupURLFunc: func(topicPrefix string) string {
+			return fmt.Sprintf("http://%s.local/paramsave", topicPrefix)
+		},
 	}
+
+	for _, option := range options {
+		option(w)
+	}
+
+	return w
 }
 
 // StartAsync starts the Worker's background jobs


### PR DESCRIPTION
This PR uses the WifiManager API to update settings (MQTT connection) and to upload the config. It can also upload latest config from Github releases.