### PR TITLE
feat(weather): add retries and timeouts for weather API calls

### DIFF
--- a/garden-app/pkg/weather/client.go
+++ b/garden-app/pkg/weather/client.go
@@ -174,7 +174,9 @@ func (c *clientWrapper) GetTotalRain(ctx context.Context, since time.Duration) (
 		return cachedData.(float32), nil
 	}
 
-	totalRain, err := c.Client.GetTotalRain(ctx, since)
+	totalRain, err := WithRetries(ctx, func(ctx context.Context) (float32, error) {
+		return c.Client.GetTotalRain(ctx, since)
+	})
 	if err != nil {
 		return 0, err
 	}
@@ -198,7 +200,9 @@ func (c *clientWrapper) GetAverageHighTemperature(ctx context.Context, since tim
 		return cachedData.(float32), nil
 	}
 
-	avgTemp, err := c.Client.GetAverageHighTemperature(ctx, since)
+	avgTemp, err := WithRetries(ctx, func(ctx context.Context) (float32, error) {
+		return c.Client.GetAverageHighTemperature(ctx, since)
+	})
 	if err != nil {
 		return 0, err
 	}
@@ -233,7 +237,9 @@ func (c *clientWrapper) GetAverageEvapotranspiration(ctx context.Context, since 
 		return 0, fmt.Errorf("weather client does not support evapotranspiration data")
 	}
 
-	avgET, err := etClient.GetAverageEvapotranspiration(ctx, since)
+	avgET, err := WithRetries(ctx, func(ctx context.Context) (float32, error) {
+		return etClient.GetAverageEvapotranspiration(ctx, since)
+	})
 	if err != nil {
 		return 0, err
 	}

--- a/garden-app/pkg/weather/client_test.go
+++ b/garden-app/pkg/weather/client_test.go
@@ -103,6 +103,58 @@ func TestCachedWeatherClient(t *testing.T) {
 	})
 }
 
+func TestWeatherClientRetriesAndCaches(t *testing.T) {
+	restore := SetRetryDelaysForTest([]time.Duration{0, 0, 0, 0})
+	defer restore()
+	defer ResetCache()
+
+	client, err := NewClient(&Config{
+		Name: "test",
+		Type: "fake",
+		Options: map[string]any{
+			"rain_mm":              25.4,
+			"rain_interval":        "24h",
+			"avg_high_temperature": 40,
+			"error":                "transient error",
+			"error_count":          2,
+		},
+	}, func(m map[string]any) error { return nil })
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+
+	rain, err := client.GetTotalRain(context.Background(), 24*time.Hour)
+	assert.NoError(t, err)
+	assert.InDelta(t, float32(25.4), rain, 0.01)
+
+	// Second call should be served from cache, so even with a permanent error
+	// configured the client should succeed.
+	rain, err = client.GetTotalRain(context.Background(), 24*time.Hour)
+	assert.NoError(t, err)
+	assert.InDelta(t, float32(25.4), rain, 0.01)
+}
+
+func TestWeatherClientRetriesPermanentError(t *testing.T) {
+	restore := SetRetryDelaysForTest([]time.Duration{0, 0, 0, 0})
+	defer restore()
+	defer ResetCache()
+
+	client, err := NewClient(&Config{
+		Name: "test",
+		Type: "fake",
+		Options: map[string]any{
+			"rain_mm":       25.4,
+			"rain_interval": "24h",
+			"error":         "permanent error",
+		},
+	}, func(m map[string]any) error { return nil })
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+
+	_, err = client.GetTotalRain(context.Background(), 24*time.Hour)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "permanent error")
+}
+
 func TestEndDated(t *testing.T) {
 	assert.False(t, (&Config{}).EndDated())
 }

--- a/garden-app/pkg/weather/fake/client.go
+++ b/garden-app/pkg/weather/fake/client.go
@@ -17,7 +17,10 @@ type Config struct {
 
 	AverageHighTemperature float32 `mapstructure:"avg_high_temperature"`
 
-	Error string `mapstructure:"error"`
+	Error      string `mapstructure:"error"`
+	ErrorCount int    `mapstructure:"error_count"`
+
+	errorCalls int
 }
 
 // Client ...
@@ -46,7 +49,7 @@ func NewClient(options map[string]any) (*Client, error) {
 
 // GetTotalRain calculates and returns the configured amount of rain for the given period
 func (c *Client) GetTotalRain(_ context.Context, since time.Duration) (float32, error) {
-	if c.Error != "" {
+	if c.shouldError() {
 		return 0, errors.New(c.Error)
 	}
 
@@ -56,9 +59,27 @@ func (c *Client) GetTotalRain(_ context.Context, since time.Duration) (float32, 
 
 // GetAverageHighTemperature returns the configured value
 func (c *Client) GetAverageHighTemperature(_ context.Context, _ time.Duration) (float32, error) {
-	if c.Error != "" {
+	if c.shouldError() {
 		return 0, errors.New(c.Error)
 	}
 
 	return c.AverageHighTemperature, nil
+}
+
+// shouldError returns true if the fake client should return an error for this call.
+// When ErrorCount is greater than zero, it returns true for the first ErrorCount
+// calls and then succeeds. When ErrorCount is zero or negative, it returns true for
+// every call if Error is set.
+func (c *Client) shouldError() bool {
+	if c.Error == "" {
+		return false
+	}
+	if c.ErrorCount > 0 {
+		if c.errorCalls < c.ErrorCount {
+			c.errorCalls++
+			return true
+		}
+		return false
+	}
+	return true
 }

--- a/garden-app/pkg/weather/internal/weatherapi/error.go
+++ b/garden-app/pkg/weather/internal/weatherapi/error.go
@@ -1,0 +1,17 @@
+// Package weatherapi provides shared types for weather API clients.
+package weatherapi
+
+import "fmt"
+
+// HTTPError represents a non-2xx HTTP response from a weather API. It is used by
+// client implementations and the retry logic to decide whether a failure is
+// transient and should be retried.
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+// Error returns a string representation of the HTTPError.
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("weather API returned status %d: %s", e.StatusCode, e.Body)
+}

--- a/garden-app/pkg/weather/netatmo/client.go
+++ b/garden-app/pkg/weather/netatmo/client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/calvinmclean/automated-garden/garden-app/clock"
+	"github.com/calvinmclean/automated-garden/garden-app/pkg/weather/internal/weatherapi"
 	"github.com/mitchellh/mapstructure"
 	"golang.org/x/sync/singleflight"
 )
@@ -151,6 +152,10 @@ func (c *Client) getStationData() (stationDataResponse, error) {
 		return stationDataResponse{}, fmt.Errorf("error reading response body with status %d: %v", resp.StatusCode, err)
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		return stationDataResponse{}, &weatherapi.HTTPError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+
 	var respData stationDataResponse
 	err = json.Unmarshal(respBody, &respData)
 	if err != nil {
@@ -259,7 +264,7 @@ func (c *Client) doRefreshToken() error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("received unexpected status %d with body: %s", resp.StatusCode, string(respBody))
+		return &weatherapi.HTTPError{StatusCode: resp.StatusCode, Body: string(respBody)}
 	}
 
 	err = json.Unmarshal(respBody, c.Authentication)

--- a/garden-app/pkg/weather/openmeteo/client.go
+++ b/garden-app/pkg/weather/openmeteo/client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/calvinmclean/automated-garden/garden-app/clock"
+	"github.com/calvinmclean/automated-garden/garden-app/pkg/weather/internal/weatherapi"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -104,7 +105,7 @@ func (c *Client) fetchData(ctx context.Context, pastDays int, dailyVars ...strin
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, &weatherapi.HTTPError{StatusCode: resp.StatusCode, Body: string(body)}
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/garden-app/pkg/weather/retry.go
+++ b/garden-app/pkg/weather/retry.go
@@ -1,0 +1,109 @@
+package weather
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/calvinmclean/automated-garden/garden-app/pkg/weather/internal/weatherapi"
+)
+
+// retryDelays are the wait periods between the initial attempt and each retry
+// for weather API calls. The initial call is made immediately, so this slice
+// represents 4 retries after transient failures.
+var retryDelays = []time.Duration{
+	1 * time.Second,
+	3 * time.Second,
+	5 * time.Second,
+	10 * time.Second,
+}
+
+// IsRetryable returns true if err represents a transient failure that is worth
+// retrying. Context cancellation is never retried; deadline exceeded, network
+// timeouts, and 5xx HTTP responses are retried.
+func IsRetryable(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Never retry if the context is already done.
+	if ctx.Err() != nil {
+		return false
+	}
+
+	// Never retry explicit cancellation.
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+
+	// Retry on deadline exceeded. The caller's context is checked between
+	// attempts, so a caller-level timeout will still stop the loop.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	// Retry network timeouts.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	// Retry 5xx HTTP responses.
+	var httpErr *weatherapi.HTTPError
+	if errors.As(err, &httpErr) && httpErr.StatusCode >= http.StatusInternalServerError {
+		return true
+	}
+
+	return false
+}
+
+// WithRetries executes operation with the configured retry delays. It returns
+// the result of the first successful attempt or the last error if all attempts
+// fail.
+func WithRetries[T any](ctx context.Context, operation func(context.Context) (T, error)) (T, error) {
+	var zero T
+
+	if ctx.Err() != nil {
+		return zero, ctx.Err()
+	}
+
+	result, err := operation(ctx)
+	if err == nil {
+		return result, nil
+	}
+	if !IsRetryable(ctx, err) {
+		return zero, err
+	}
+
+	for _, delay := range retryDelays {
+		select {
+		case <-ctx.Done():
+			return zero, ctx.Err()
+		case <-time.After(delay):
+		}
+
+		result, err = operation(ctx)
+		if err == nil {
+			return result, nil
+		}
+		if !IsRetryable(ctx, err) {
+			return zero, err
+		}
+	}
+
+	return zero, err
+}
+
+// SetRetryDelaysForTest overrides the retry delays used by WithRetries. It
+// returns a function that restores the original delays. This is intended for
+// tests that need to exercise retry logic without waiting for the production
+// backoff schedule.
+func SetRetryDelaysForTest(delays []time.Duration) func() {
+	original := retryDelays
+	retryDelays = delays
+	return func() {
+		retryDelays = original
+	}
+}

--- a/garden-app/pkg/weather/retry_test.go
+++ b/garden-app/pkg/weather/retry_test.go
@@ -1,0 +1,190 @@
+package weather
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/calvinmclean/automated-garden/garden-app/pkg/weather/internal/weatherapi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithRetries_SuccessFirstAttempt(t *testing.T) {
+	restore := SetRetryDelaysForTest([]time.Duration{0, 0, 0, 0})
+	defer restore()
+
+	calls := 0
+	result, err := WithRetries(context.Background(), func(ctx context.Context) (int, error) {
+		calls++
+		return 42, nil
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 42, result)
+	assert.Equal(t, 1, calls)
+}
+
+func TestWithRetries_SuccessAfterFailures(t *testing.T) {
+	restore := SetRetryDelaysForTest([]time.Duration{0, 0, 0, 0})
+	defer restore()
+
+	calls := 0
+	result, err := WithRetries(context.Background(), func(ctx context.Context) (int, error) {
+		calls++
+		if calls < 3 {
+			return 0, &weatherapi.HTTPError{StatusCode: http.StatusServiceUnavailable, Body: "unavailable"}
+		}
+		return 42, nil
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 42, result)
+	assert.Equal(t, 3, calls)
+}
+
+func TestWithRetries_NonRetryableHTTPError(t *testing.T) {
+	restore := SetRetryDelaysForTest([]time.Duration{0, 0, 0, 0})
+	defer restore()
+
+	calls := 0
+	_, err := WithRetries(context.Background(), func(ctx context.Context) (int, error) {
+		calls++
+		return 0, &weatherapi.HTTPError{StatusCode: http.StatusBadRequest, Body: "bad request"}
+	})
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestWithRetries_MaxRetriesExceeded(t *testing.T) {
+	restore := SetRetryDelaysForTest([]time.Duration{0, 0, 0, 0})
+	defer restore()
+
+	calls := 0
+	_, err := WithRetries(context.Background(), func(ctx context.Context) (int, error) {
+		calls++
+		return 0, &weatherapi.HTTPError{StatusCode: http.StatusServiceUnavailable, Body: "unavailable"}
+	})
+
+	assert.Error(t, err)
+	assert.Equal(t, 5, calls) // initial + 4 retries
+}
+
+func TestWithRetries_ContextCancelled(t *testing.T) {
+	restore := SetRetryDelaysForTest([]time.Duration{time.Hour, time.Hour, time.Hour, time.Hour})
+	defer restore()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calls := 0
+	_, err := WithRetries(ctx, func(ctx context.Context) (int, error) {
+		calls++
+		return 0, errors.New("transient")
+	})
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, calls)
+}
+
+func TestWithRetries_ContextDeadline(t *testing.T) {
+	restore := SetRetryDelaysForTest([]time.Duration{time.Hour, time.Hour, time.Hour, time.Hour})
+	defer restore()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	// Wait for the deadline to expire.
+	time.Sleep(5 * time.Millisecond)
+
+	calls := 0
+	_, err := WithRetries(ctx, func(ctx context.Context) (int, error) {
+		calls++
+		return 0, context.DeadlineExceeded
+	})
+
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 0, calls)
+}
+
+func TestWithRetries_NetworkError(t *testing.T) {
+	restore := SetRetryDelaysForTest([]time.Duration{0, 0, 0, 0})
+	defer restore()
+
+	calls := 0
+	_, err := WithRetries(context.Background(), func(ctx context.Context) (int, error) {
+		calls++
+		return 0, &net.DNSError{Err: "timeout", IsTimeout: true}
+	})
+
+	assert.Error(t, err)
+	assert.Equal(t, 5, calls)
+}
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name      string
+		ctx       context.Context
+		err       error
+		retryable bool
+	}{
+		{
+			name:      "nil error",
+			ctx:       context.Background(),
+			err:       nil,
+			retryable: false,
+		},
+		{
+			name:      "context canceled",
+			ctx:       context.Background(),
+			err:       context.Canceled,
+			retryable: false,
+		},
+		{
+			name:      "context deadline exceeded",
+			ctx:       context.Background(),
+			err:       context.DeadlineExceeded,
+			retryable: true,
+		},
+		{
+			name:      "5xx HTTP error",
+			ctx:       context.Background(),
+			err:       &weatherapi.HTTPError{StatusCode: http.StatusServiceUnavailable},
+			retryable: true,
+		},
+		{
+			name:      "4xx HTTP error",
+			ctx:       context.Background(),
+			err:       &weatherapi.HTTPError{StatusCode: http.StatusBadRequest},
+			retryable: false,
+		},
+		{
+			name:      "wrapped 5xx HTTP error",
+			ctx:       context.Background(),
+			err:       errors.New("wrapped: " + (&weatherapi.HTTPError{StatusCode: http.StatusGatewayTimeout}).Error()),
+			retryable: false, // string wrapping breaks errors.As
+		},
+		{
+			name:      "wrapped 5xx with fmt.Errorf %w",
+			ctx:       context.Background(),
+			err:       fmt.Errorf("wrapped: %w", &weatherapi.HTTPError{StatusCode: http.StatusGatewayTimeout}),
+			retryable: true,
+		},
+		{
+			name:      "cancelled context error",
+			ctx:       func() context.Context { ctx, cancel := context.WithCancel(context.Background()); cancel(); return ctx }(),
+			err:       errors.New("transient"),
+			retryable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.retryable, IsRetryable(tt.ctx, tt.err))
+		})
+	}
+}

--- a/garden-app/server/water_schedule_responses.go
+++ b/garden-app/server/water_schedule_responses.go
@@ -30,8 +30,8 @@ func GetNextWaterDetails(r *http.Request, ws *pkg.WaterSchedule, worker *worker.
 	}
 
 	if ws.HasWeatherControl() && !excludeWeatherData {
-		wd, hadErr := worker.ScaleWateringDuration(ws)
-		if hadErr {
+		wd, err := worker.ScaleWateringDuration(ws)
+		if err != nil {
 			result.Message = "error impacted duration scaling"
 		}
 

--- a/garden-app/worker/scheduler.go
+++ b/garden-app/worker/scheduler.go
@@ -55,7 +55,11 @@ func (w *Worker) ScheduleWaterAction(waterSchedule *pkg.WaterSchedule) error {
 				// Calculate duration for weather control (for notifications and zone watering)
 				duration := ws.Duration.Duration
 				if ws.HasWeatherControl() {
-					duration, _ = w.ScaleWateringDuration(ws)
+					scaledDuration, err := w.ScaleWateringDuration(ws)
+					if err != nil {
+						jobLogger.Warn("weather data unavailable, proceeding with unscaled duration", "error", err)
+					}
+					duration = scaledDuration
 				}
 
 				// Get zones using this WaterSchedule (for notifications and watering)

--- a/garden-app/worker/water_schedule_actions.go
+++ b/garden-app/worker/water_schedule_actions.go
@@ -10,6 +10,12 @@ import (
 	"github.com/calvinmclean/automated-garden/garden-app/pkg/weather"
 )
 
+// weatherDataTimeout caps how long the worker will wait for a single weather
+// API call, including retries. A separate timeout is used for each metric
+// (rain, temperature, evapotranspiration) to prevent a single stalled request
+// from blocking the scheduled watering indefinitely.
+const weatherDataTimeout = 30 * time.Second
+
 // ExecuteScheduledWaterAction will run ExecuteWaterAction after checking SkipCount
 func (w *Worker) ExecuteScheduledWaterAction(ctx context.Context, g *pkg.Garden, z *pkg.Zone, ws *pkg.WaterSchedule, duration time.Duration) error {
 	if z.SkipCount != nil && *z.SkipCount > 0 {
@@ -41,7 +47,7 @@ func (w *Worker) ExecuteScheduledWaterAction(ctx context.Context, g *pkg.Garden,
 // CalculateETDuration calculates watering duration based on ET data using the citrus tree formula.
 // Returns (duration, true) if ET calculation succeeds, (0, false) otherwise.
 // This completely overrides the configured duration when successful.
-func (w *Worker) CalculateETDuration(ws *pkg.WaterSchedule) (time.Duration, bool) {
+func (w *Worker) CalculateETDuration(ctx context.Context, ws *pkg.WaterSchedule) (time.Duration, bool) {
 	if !ws.HasEvapotranspirationControl() {
 		return 0, false
 	}
@@ -69,7 +75,7 @@ func (w *Worker) CalculateETDuration(ws *pkg.WaterSchedule) (time.Duration, bool
 	}
 
 	// Fetch average ET over the interval (minimum 24h enforced by client)
-	avgET, err := etProvider.GetAverageEvapotranspiration(context.Background(), ws.Interval.Duration)
+	avgET, err := etProvider.GetAverageEvapotranspiration(ctx, ws.Interval.Duration)
 	if err != nil {
 		w.logger.Warn("error getting evapotranspiration data", "error", err)
 		return 0, false
@@ -91,17 +97,21 @@ func (w *Worker) CalculateETDuration(ws *pkg.WaterSchedule) (time.Duration, bool
 	return duration, true
 }
 
-// ScaleWateringDuration returns a new watering duration based on weather scaling. It will not return
-// any errors if they are encountered because there are multiple factors impacting watering.
-// If ET control is configured and succeeds, it provides the base duration which can then be scaled
-// by temperature and rain controls if they are also configured.
-func (w *Worker) ScaleWateringDuration(ws *pkg.WaterSchedule) (time.Duration, bool) {
+// ScaleWateringDuration returns a new watering duration based on weather scaling.
+// If any weather API fails, the last error is returned and the unscaled duration
+// is used so that scheduled watering is not blocked by transient weather service
+// issues. If ET control is configured and succeeds, it provides the base duration
+// which can then be scaled by temperature and rain controls if they are also configured.
+func (w *Worker) ScaleWateringDuration(ws *pkg.WaterSchedule) (time.Duration, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), weatherDataTimeout)
+	defer cancel()
+
 	baseDuration := ws.Duration.Duration
 	scaleFactor := 1.0
-	hadError := false
+	var lastErr error
 
 	if ws.HasEvapotranspirationControl() {
-		etDuration, ok := w.CalculateETDuration(ws)
+		etDuration, ok := w.CalculateETDuration(ctx, ws)
 		if ok {
 			baseDuration = etDuration
 			w.logger.Debug("using ET-calculated duration as base", "et_duration", etDuration)
@@ -111,12 +121,12 @@ func (w *Worker) ScaleWateringDuration(ws *pkg.WaterSchedule) (time.Duration, bo
 	if ws.HasTemperatureControl() {
 		weatherClient, err := w.storageClient.GetWeatherClient(ws.WeatherControl.Temperature.ClientID)
 		if err != nil {
-			hadError = true
+			lastErr = err
 			w.logger.Warn("error getting WeatherClient for TemperatureControl", "error", err)
 		} else {
-			avgHighTemp, err := weatherClient.GetAverageHighTemperature(context.Background(), ws.Interval.Duration)
+			avgHighTemp, err := weatherClient.GetAverageHighTemperature(ctx, ws.Interval.Duration)
 			if err != nil {
-				hadError = true
+				lastErr = err
 				w.logger.Warn("error getting average high temperatures", "error", err)
 			} else {
 				tempScaleFactor := ws.WeatherControl.Temperature.Scale(float64(avgHighTemp))
@@ -133,12 +143,12 @@ func (w *Worker) ScaleWateringDuration(ws *pkg.WaterSchedule) (time.Duration, bo
 	if ws.HasRainControl() {
 		weatherClient, err := w.storageClient.GetWeatherClient(ws.WeatherControl.Rain.ClientID)
 		if err != nil {
-			hadError = true
+			lastErr = err
 			w.logger.Warn("error getting WeatherClient for RainControl", "error", err)
 		} else {
-			totalRain, err := weatherClient.GetTotalRain(context.Background(), ws.Interval.Duration)
+			totalRain, err := weatherClient.GetTotalRain(ctx, ws.Interval.Duration)
 			if err != nil {
-				hadError = true
+				lastErr = err
 				w.logger.Warn("error getting rain data", "error", err)
 			} else {
 				rainScaleFactor := ws.WeatherControl.Rain.Scale(float64(totalRain))
@@ -156,7 +166,7 @@ func (w *Worker) ScaleWateringDuration(ws *pkg.WaterSchedule) (time.Duration, bo
 
 	result := time.Duration(float64(baseDuration) * scaleFactor)
 	if result.Milliseconds() == 0 {
-		return 0, hadError
+		return 0, lastErr
 	}
-	return result, hadError
+	return result, lastErr
 }

--- a/garden-app/worker/water_schedule_actions_test.go
+++ b/garden-app/worker/water_schedule_actions_test.go
@@ -176,6 +176,7 @@ func TestScaleWateringDuration(t *testing.T) {
 		waterSchedule    *pkg.WaterSchedule
 		setupWeather     func(*storage.Client)
 		expectedDuration time.Duration
+		expectedError    string
 	}{
 		{
 			name: "NoWeatherControl",
@@ -408,6 +409,7 @@ func TestScaleWateringDuration(t *testing.T) {
 				})
 			},
 			expectedDuration: time.Second,
+			expectedError:    "weather client error",
 		},
 	}
 
@@ -422,9 +424,18 @@ func TestScaleWateringDuration(t *testing.T) {
 			tt.setupWeather(sc)
 
 			worker := NewWorker(sc, new(influxdb.MockClient), new(mqtt.MockClient), slog.Default())
-			duration, _ := worker.ScaleWateringDuration(tt.waterSchedule)
+			restoreDelays := weather.SetRetryDelaysForTest([]time.Duration{0, 0, 0, 0})
+			defer restoreDelays()
+
+			duration, err := worker.ScaleWateringDuration(tt.waterSchedule)
 
 			assert.Equal(t, tt.expectedDuration, duration)
+			if tt.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, tt.expectedError)
+			}
 		})
 	}
 }


### PR DESCRIPTION
- Add WithRetries helper with 1s/3s/5s/10s backoff

- Retry only transient errors: network timeouts, 5xx, deadline exceeded

- Add 30s per-call timeout in worker weather scaling

- Surface weather fetch errors in scheduler while keeping unscaled fallback

- Keep existing 5-minute in-memory cache for successful responses